### PR TITLE
Move structs to avalanche_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avalanche-types"
-version = "0.0.370"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db6c77f08eca07902a4c9ad646cc0e6e5cda9a0a6a7ae27a4a0383eb320e1a1"
+version = "0.0.368"
+source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=33-jsonrpc-update#bba338a0ae1f9809cae06affb7f7bb2b9a43917e"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",
@@ -1160,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "e7c99d16b88c92aef47e58dadd53e87b4bd234c29934947a6cec8b466300f99b"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1170,27 +1169,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "2ea05d2fcb27b53f7a98faddaf5f2914760330ab7703adfc9df13332b42189f9"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "7bfb82b62b1b8a2a9808fb4caf844ede819a76cfc23b2827d7f94eefb49551eb"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3927,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331bb8c3bf9b92457ab7abecf07078c13f7d270ba490103e84e8b014490cd0b0"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3943,14 +3942,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859011bddcc11f289f07f467cc1fe01c7a941daa4d8f6c40d4d1c92eb6d9319c"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avalanche-types"
 version = "0.0.379"
-source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=68-ids-from-owned-strings#107992684b073869b4a3ece9164f351b5c83cc70"
+source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=update-info-jsonrpc-responses#c0bae5724ad635de0dc4656deac915c581123a74"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arrayvec"
@@ -146,7 +146,7 @@ version = "0.1.1"
 dependencies = [
  "ash_sdk",
  "async-std",
- "clap 4.2.4",
+ "clap 4.2.7",
  "colored",
  "exitcode",
  "indent",
@@ -171,6 +171,45 @@ dependencies = [
  "tempfile",
  "thiserror",
  "ureq",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.21",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -339,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
+checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -357,18 +396,19 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avalanche-types"
-version = "0.0.368"
-source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=33-jsonrpc-update#bba338a0ae1f9809cae06affb7f7bb2b9a43917e"
+version = "0.0.379"
+source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=68-ids-from-owned-strings#107992684b073869b4a3ece9164f351b5c83cc70"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",
  "blst",
  "bs58",
  "bytes",
+ "cert-manager",
  "chrono",
  "cmp-manager",
  "ecdsa 0.16.6",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "hex",
  "hmac",
  "k256 0.13.1",
@@ -382,14 +422,13 @@ dependencies = [
  "ring",
  "ripemd",
  "rust-embed",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_with",
  "serde_yaml",
  "sha2 0.10.6",
  "sha3",
- "spki 0.7.1",
+ "spki 0.7.2",
  "thiserror",
  "url",
  "zerocopy",
@@ -690,6 +729,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cert-manager"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166da6fda67aa44381158b8ad9c3b28d842951791c431ce61333e62cb9b05d5b"
+dependencies = [
+ "log",
+ "rand",
+ "random-manager",
+ "rcgen",
+ "rsa",
+ "rustls 0.21.1",
+ "rustls-pemfile",
+ "x509-parser 0.15.0",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,13 +787,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.2.18",
+ "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -749,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
@@ -760,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -773,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1074,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core",
@@ -1159,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c99d16b88c92aef47e58dadd53e87b4bd234c29934947a6cec8b466300f99b"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1169,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea05d2fcb27b53f7a98faddaf5f2914760330ab7703adfc9df13332b42189f9"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1183,14 +1238,20 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfb82b62b1b8a2a9808fb4caf844ede819a76cfc23b2827d7f94eefb49551eb"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.15",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "der"
@@ -1209,7 +1270,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1293,6 +1369,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.5.1",
+ "crypto-bigint 0.5.2",
  "digest 0.10.6",
  "ff 0.13.0",
  "generic-array 0.14.7",
@@ -1609,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5f8f85ba96698eab9a4782ed2215d0979b1981b99f1be0726c200ffdac22f5"
+checksum = "198ea9efa8480fa69f73d31d41b1601dace13d053c6fe4be6f5878d9dfcf0108"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1685,7 +1772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a9e0597aa6b2fdc810ff58bc95e4eeaa2c219b3e615ed025106ecb027407d8"
 dependencies = [
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl 1.1.0",
  "base64 0.13.1",
  "ethers-core 1.0.2",
  "futures-core",
@@ -1841,9 +1928,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2181,11 +2268,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2254,7 +2341,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls",
 ]
@@ -2514,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -2532,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.10"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ada7ece1f5bc6d36eec2a4dc204135f14888209b3773df8fefcfe990fd4cbc"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -2544,7 +2631,6 @@ dependencies = [
  "itertools",
  "lalrpop-util",
  "petgraph",
- "pico-args",
  "regex",
  "regex-syntax 0.6.29",
  "string_cache",
@@ -2555,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.10"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3b45d694c8074f77bc24fc26e47633c862a9cd3b48dd51209c02ba4c434d68"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
 dependencies = [
  "regex",
 ]
@@ -2567,12 +2653,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
@@ -2591,9 +2686,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -2653,9 +2748,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -2713,6 +2808,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,12 +2846,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2769,6 +2904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,7 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
 dependencies = [
  "arrayvec",
- "auto_impl 1.0.1",
+ "auto_impl 1.1.0",
  "bytes",
  "ethereum-types",
  "open-fastrlp-derive",
@@ -2873,9 +3017,9 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
+checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
 dependencies = [
  "arrayvec",
  "bitvec 1.0.1",
@@ -2987,6 +3131,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,9 +3156,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3004,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3014,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3027,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
@@ -3101,12 +3263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3295,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.5",
+ "pkcs8 0.10.2",
+ "spki 0.7.2",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,14 +3322,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.5",
- "spki 0.7.1",
+ "spki 0.7.2",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "polling"
@@ -3357,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -3407,6 +3574,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "random-manager"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2557c07161d4d805cd7e711d0648b292be9e727d9678d078bab052278cd1b71"
+dependencies = [
+ "bs58",
+ "lazy_static",
+ "primitive-types",
+ "rand",
+ "ring",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3426,6 +3606,19 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.21",
+ "x509-parser 0.14.0",
+ "yasna",
 ]
 
 [[package]]
@@ -3482,9 +3675,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3505,7 +3698,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -3602,6 +3795,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+dependencies = [
+ "byteorder",
+ "const-oid",
+ "digest 0.10.6",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "signature 2.1.0",
+ "spki 0.7.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust-embed"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,10 +3876,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.14"
+name = "rusticata-macros"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -3687,6 +3911,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,6 +3941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3739,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
+checksum = "dfdef77228a4c05dc94211441595746732131ad7f6530c6c18f045da7b7ab937"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -3751,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
+checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3872,9 +4118,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -3892,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3926,25 +4172,25 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "chrono",
  "hex",
  "indexmap",
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4025,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -4124,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der 0.7.5",
@@ -4193,7 +4439,7 @@ checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
 dependencies = [
  "anyhow",
  "cfg-if",
- "clap 3.2.23",
+ "clap 3.2.25",
  "console 0.14.1",
  "dialoguer",
  "fs2",
@@ -4236,6 +4482,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4335,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -4347,15 +4605,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4386,9 +4644,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4400,14 +4658,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4430,7 +4688,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
 ]
@@ -4443,7 +4701,7 @@ checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls",
  "tungstenite",
@@ -4453,9 +4711,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4571,7 +4829,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.20.8",
  "sha-1",
  "thiserror",
  "url",
@@ -4664,7 +4922,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "serde",
  "serde_json",
@@ -5076,9 +5334,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
@@ -5121,6 +5379,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.21",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.21",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5134,6 +5428,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time 0.3.21",
+]
 
 [[package]]
 name = "zerocopy"
@@ -5178,9 +5481,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "7e92305c174683d78035cbf1b70e18db6329cc0f1b9cae0a52ca90bf5bfe7125"
 dependencies = [
  "aes 0.7.5",
  "byteorder",
@@ -5192,7 +5495,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.20",
+ "time 0.3.21",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ categories = [
 keywords = ["blockchain", "avalanche", "subnets", "ash"]
 
 [patch.crates-io]
-avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "68-ids-from-owned-strings" }
+avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "update-info-jsonrpc-responses" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ categories = [
 	"data-structures",
 ]
 keywords = ["blockchain", "avalanche", "subnets", "ash"]
+
+[patch.crates-io]
+avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "33-jsonrpc-update" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ categories = [
 keywords = ["blockchain", "avalanche", "subnets", "ash"]
 
 [patch.crates-io]
-avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "33-jsonrpc-update" }
+avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "68-ids-from-owned-strings" }

--- a/crates/ash_cli/src/avalanche/subnet.rs
+++ b/crates/ash_cli/src/avalanche/subnet.rs
@@ -44,7 +44,7 @@ fn list(network_name: &str, config: Option<&str>, json: bool) -> Result<(), CliE
     }
 
     println!(
-        "Found {} Subnet(s) on '{}':",
+        "Found {} Subnet(s) on network '{}':",
         type_colorize(&network.subnets.len()),
         type_colorize(&network.name)
     );

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -62,7 +62,7 @@ fn list(
     }
 
     println!(
-        "Found {} Subnet(s) on '{}':",
+        "Found {} validator(s) on Subnet '{}':",
         subnet.validators.len(),
         subnet_id
     );

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "33-jsonrpc-update" }
+avalanche-types = "0.0.368"
 config = { version = "0.13.3", features = ["yaml"] }
 ethers = { version = "1.0.2", features = ["rustls"] }
 hex = "0.4.3"

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-avalanche-types = "0.0"
+avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "33-jsonrpc-update" }
 config = { version = "0.13.3", features = ["yaml"] }
 ethers = { version = "1.0.2", features = ["rustls"] }
 hex = "0.4.3"

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-avalanche-types = "0.0.368"
+avalanche-types = "0.0.379"
 config = { version = "0.13.3", features = ["yaml"] }
 ethers = { version = "1.0.2", features = ["rustls"] }
 hex = "0.4.3"

--- a/crates/ash_sdk/conf/default.yml
+++ b/crates/ash_sdk/conf/default.yml
@@ -6,8 +6,6 @@ avalancheNetworks:
   - name: mainnet
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -26,8 +24,6 @@ avalancheNetworks:
   - name: fuji
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -46,8 +42,6 @@ avalancheNetworks:
   - name: mainnet-ankr
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -66,8 +60,6 @@ avalancheNetworks:
   - name: fuji-ankr
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -86,8 +78,6 @@ avalancheNetworks:
   - name: mainnet-blast
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -106,8 +96,6 @@ avalancheNetworks:
   - name: fuji-blast
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain

--- a/crates/ash_sdk/src/avalanche/blockchains.rs
+++ b/crates/ash_sdk/src/avalanche/blockchains.rs
@@ -3,8 +3,8 @@
 
 // Module that contains code to interact with Avalanche blockchains
 
-use crate::{avalanche::avalanche_id_from_string, errors::*};
-use avalanche_types::ids::Id;
+use crate::errors::*;
+use avalanche_types::{ids::Id, jsonrpc::platformvm::Blockchain};
 use ethers::providers::{Http, Provider};
 use serde::{Deserialize, Serialize};
 
@@ -12,12 +12,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AvalancheBlockchain {
-    #[serde(deserialize_with = "avalanche_id_from_string")]
     pub id: Id,
     pub name: String,
-    #[serde(deserialize_with = "avalanche_id_from_string", skip)]
+    #[serde(skip)]
     pub subnet_id: Id,
-    #[serde(default, deserialize_with = "avalanche_id_from_string")]
+    #[serde(default)]
     pub vm_id: Id,
     #[serde(default)]
     pub vm_type: String,
@@ -46,6 +45,18 @@ impl AvalancheBlockchain {
                 ),
             }
             .into()),
+        }
+    }
+}
+
+impl From<Blockchain> for AvalancheBlockchain {
+    fn from(blockchain: Blockchain) -> Self {
+        Self {
+            id: blockchain.id,
+            name: blockchain.name,
+            subnet_id: blockchain.subnet_id,
+            vm_id: blockchain.vm_id,
+            ..Default::default()
         }
     }
 }

--- a/crates/ash_sdk/src/avalanche/jsonrpc.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc.rs
@@ -3,3 +3,54 @@
 
 pub mod info;
 pub mod platformvm;
+
+// Module that contains code to interact with the Avalanche JSON RPC endpoints
+
+use crate::errors::*;
+use avalanche_types::jsonrpc::ResponseError;
+use ureq;
+
+/// Trait that defines the methods to get the result and error of a JSON RPC response
+/// This is used to avoid code duplication when posting JSON RPC requests
+pub trait JsonRpcResponse<Resp, Res>
+where
+    Resp: serde::de::DeserializeOwned,
+    Res: serde::de::DeserializeOwned,
+{
+    fn get_error(&self) -> Option<ResponseError>;
+    fn get_result(&self) -> Option<Res>;
+}
+
+/// Get the result of a response from a JSON RPC request
+/// If the response contains an error, return an error instead
+pub fn get_json_rpc_req_result<Resp, Res>(
+    rpc_url: &str,
+    method: &str,
+    params: Option<ureq::serde_json::Value>,
+) -> Result<Res, RpcError>
+where
+    Resp: serde::de::DeserializeOwned,
+    Res: serde::de::DeserializeOwned,
+    Resp: JsonRpcResponse<Resp, Res>,
+{
+    let resp: Resp = ureq::post(rpc_url)
+        .send_json(ureq::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1
+        }))
+        .map_err(|e| RpcError::Unknown(e.to_string()))?
+        .into_json()
+        .map_err(|e| RpcError::Unknown(e.to_string()))?;
+
+    if resp.get_error().is_some() {
+        Err(RpcError::ResponseError {
+            code: resp.get_error().unwrap().code,
+            message: resp.get_error().unwrap().message,
+            data: resp.get_error().unwrap().data,
+        })
+    } else {
+        Ok(resp.get_result().unwrap())
+    }
+}

--- a/crates/ash_sdk/src/avalanche/jsonrpc.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc.rs
@@ -21,6 +21,22 @@ where
     fn get_result(&self) -> Option<Res>;
 }
 
+/// Macro that implements the JsonRpcResponse trait for a response type and its result type
+#[macro_export]
+macro_rules! impl_json_rpc_response {
+    ($resp_type:ty, $res_type:ty) => {
+        impl JsonRpcResponse<$resp_type, $res_type> for $resp_type {
+            fn get_error(&self) -> Option<ResponseError> {
+                self.error.clone()
+            }
+
+            fn get_result(&self) -> Option<$res_type> {
+                self.result.clone()
+            }
+        }
+    };
+}
+
 /// Get the result of a response from a JSON RPC request
 /// If the response contains an error, return an error instead
 pub fn get_json_rpc_req_result<Resp, Res>(

--- a/crates/ash_sdk/src/avalanche/jsonrpc.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc.rs
@@ -44,11 +44,11 @@ where
         .into_json()
         .map_err(|e| RpcError::Unknown(e.to_string()))?;
 
-    if resp.get_error().is_some() {
+    if let Some(error) = resp.get_error() {
         Err(RpcError::ResponseError {
-            code: resp.get_error().unwrap().code,
-            message: resp.get_error().unwrap().message,
-            data: resp.get_error().unwrap().data,
+            code: error.code,
+            message: error.message,
+            data: error.data,
         })
     } else {
         Ok(resp.get_result().unwrap())

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -3,8 +3,10 @@
 
 // Module that contains code to interact with Avalanche Info API
 
-use crate::avalanche::avalanche_node_id_from_string;
-use crate::avalanche::nodes::{AvalancheNodeUptime, AvalancheNodeVersions};
+use crate::avalanche::{
+    avalanche_node_id_from_string,
+    nodes::{AvalancheNodeUptime, AvalancheNodeVersions},
+};
 use avalanche_types::{ids::node::Id, jsonrpc::info::*};
 use serde::Deserialize;
 use serde_aux::prelude::*;

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -3,10 +3,7 @@
 
 // Module that contains code to interact with Avalanche Info API
 
-use crate::avalanche::{
-    avalanche_node_id_from_string,
-    nodes::{AvalancheNodeUptime, AvalancheNodeVersions},
-};
+use crate::avalanche::nodes::{AvalancheNodeUptime, AvalancheNodeVersions};
 use avalanche_types::{ids::node::Id, jsonrpc::info::*};
 use serde::Deserialize;
 use serde_aux::prelude::*;
@@ -25,7 +22,7 @@ struct InfoApiGetNodeIdResponse {
 
 #[derive(Deserialize)]
 struct InfoApiGetNodeIdResult {
-    #[serde(rename = "nodeID", deserialize_with = "avalanche_node_id_from_string")]
+    #[serde(rename = "nodeID")]
     node_id: Id,
 }
 

--- a/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
@@ -3,18 +3,36 @@
 
 // Module that contains code to interact with Avalanche PlatformVM API
 
-use crate::avalanche::blockchains::AvalancheBlockchain;
-use crate::avalanche::subnets::{
-    AvalancheSubnet, AvalancheSubnetDelegator, AvalancheSubnetValidator,
-};
 use crate::avalanche::{
-    avalanche_id_from_string, avalanche_node_id_from_string, AvalancheOutputOwners,
+    avalanche_id_from_string,
+    blockchains::AvalancheBlockchain,
+    jsonrpc::{get_json_rpc_req_result, JsonRpcResponse},
+    subnets::{AvalancheSubnet, AvalancheSubnetValidator},
 };
-use avalanche_types::{ids::node::Id as NodeId, ids::Id};
+use crate::errors::*;
+use avalanche_types::{
+    ids::Id,
+    jsonrpc::{
+        platformvm::{GetCurrentValidatorsResponse, GetCurrentValidatorsResult},
+        ResponseError,
+    },
+};
 use serde::Deserialize;
 use serde_aux::prelude::*;
 use std::str::FromStr;
 use ureq;
+
+impl JsonRpcResponse<GetCurrentValidatorsResponse, GetCurrentValidatorsResult>
+    for GetCurrentValidatorsResponse
+{
+    fn get_error(&self) -> Option<ResponseError> {
+        self.error.clone()
+    }
+
+    fn get_result(&self) -> Option<GetCurrentValidatorsResult> {
+        self.result.clone()
+    }
+}
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
@@ -64,80 +82,6 @@ struct PlatformApiBlockchain {
     subnet_id: Id,
     #[serde(alias = "vmID", deserialize_with = "avalanche_id_from_string")]
     vm_id: Id,
-}
-
-#[derive(Deserialize)]
-#[allow(dead_code)]
-struct PlatformApiGetCurrentValidatorsResponse {
-    jsonrpc: String,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    id: u8,
-    result: PlatformApiGetCurrentValidatorsResult,
-}
-
-#[derive(Deserialize)]
-struct PlatformApiGetCurrentValidatorsResult {
-    validators: Vec<PlatformApiValidator>,
-}
-
-#[derive(Default, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
-struct PlatformApiValidator {
-    #[serde(rename = "txID", deserialize_with = "avalanche_id_from_string")]
-    tx_id: Id,
-    #[serde(rename = "nodeID", deserialize_with = "avalanche_node_id_from_string")]
-    node_id: NodeId,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    start_time: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    end_time: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    stake_amount: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    weight: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    potential_reward: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    delegation_fee: f32,
-    connected: bool,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    uptime: f32,
-    validation_reward_owner: PlatformApiRewardOwner,
-    delegators: Option<Vec<PlatformApiDelegator>>,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    delegator_count: u32,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    delegator_weight: u64,
-    delegation_reward_owner: PlatformApiRewardOwner,
-}
-
-#[derive(Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PlatformApiDelegator {
-    #[serde(rename = "txID", deserialize_with = "avalanche_id_from_string")]
-    tx_id: Id,
-    #[serde(rename = "nodeID", deserialize_with = "avalanche_node_id_from_string")]
-    node_id: NodeId,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    start_time: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    end_time: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    stake_amount: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    weight: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    potential_reward: u64,
-}
-
-#[derive(Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PlatformApiRewardOwner {
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    locktime: u64,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    threshold: u32,
-    addresses: Vec<String>,
 }
 
 // Get the Subnets of the network by querying the P-Chain API
@@ -198,62 +142,27 @@ pub fn get_network_blockchains(rpc_url: &str) -> Result<Vec<AvalancheBlockchain>
 pub fn get_current_validators(
     rpc_url: &str,
     subnet_id: &str,
-) -> Result<Vec<AvalancheSubnetValidator>, ureq::Error> {
-    let resp: PlatformApiGetCurrentValidatorsResponse = ureq::post(rpc_url)
-        .send_json(ureq::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "platform.getCurrentValidators",
-            "params": {
-                "subnetID": subnet_id
-            }
-        }))?
-        .into_json()?;
-
-    let current_validators = resp
-        .result
+) -> Result<Vec<AvalancheSubnetValidator>, RpcError> {
+    let current_validators =
+        get_json_rpc_req_result::<GetCurrentValidatorsResponse, GetCurrentValidatorsResult>(
+            rpc_url,
+            "platform.getCurrentValidators",
+            Some(ureq::json!({ "subnetID": subnet_id })),
+        )?
         .validators
+        .ok_or(RpcError::GetFailure {
+            data_type: "validators".to_string(),
+            target_type: "Subnet".to_string(),
+            target_value: subnet_id.to_string(),
+            msg: "No validators found".to_string(),
+        })?
         .iter()
-        .map(|validator| AvalancheSubnetValidator {
-            tx_id: validator.tx_id,
-            node_id: validator.node_id,
-            subnet_id: Id::from_str(subnet_id).unwrap(),
-            start_time: validator.start_time,
-            end_time: validator.end_time,
-            stake_amount: validator.stake_amount,
-            weight: validator.weight,
-            potential_reward: validator.potential_reward,
-            delegation_fee: validator.delegation_fee,
-            connected: validator.connected,
-            uptime: validator.uptime,
-            validation_reward_owner: AvalancheOutputOwners {
-                locktime: validator.validation_reward_owner.locktime,
-                threshold: validator.validation_reward_owner.threshold,
-                addresses: validator.validation_reward_owner.addresses.clone(),
-            },
-            delegators: match &validator.delegators {
-                Some(delegators) => delegators
-                    .iter()
-                    .map(|delegator| AvalancheSubnetDelegator {
-                        tx_id: delegator.tx_id,
-                        node_id: delegator.node_id,
-                        start_time: delegator.start_time,
-                        end_time: delegator.end_time,
-                        stake_amount: delegator.stake_amount,
-                        weight: delegator.weight,
-                        potential_reward: delegator.potential_reward,
-                        ..Default::default()
-                    })
-                    .collect(),
-                None => Default::default(),
-            },
-            delegator_count: validator.delegator_count,
-            delegator_weight: validator.delegator_weight,
-            delegation_reward_owner: AvalancheOutputOwners {
-                locktime: validator.delegation_reward_owner.locktime,
-                threshold: validator.delegation_reward_owner.threshold,
-                addresses: validator.delegation_reward_owner.addresses.clone(),
-            },
+        .map(|validator| {
+            AvalancheSubnetValidator::from_api_primary_validator(
+                validator,
+                // Unwrap is safe because we checked for a response error above
+                Id::from_str(subnet_id).unwrap(),
+            )
         })
         .collect();
 
@@ -264,6 +173,7 @@ pub fn get_current_validators(
 mod tests {
     use super::*;
     use crate::avalanche::AvalancheNetwork;
+    use avalanche_types::ids::node::Id as NodeId;
     use std::env;
 
     const AVAX_PRIMARY_NETWORK_ID: &str = "11111111111111111111111111111111LpoYY";
@@ -334,10 +244,10 @@ mod tests {
         // Test that the node has a non-zero uptime
         assert!(ava_labs_node.uptime > 0.0);
         // Test that the node has a non-zero weight
-        assert!(ava_labs_node.weight > 0);
+        assert!(ava_labs_node.weight > Some(0));
         // Test that the node has a non-zero potential reward
-        assert!(ava_labs_node.potential_reward > 0);
+        assert!(ava_labs_node.potential_reward > Some(0));
         // Test that the node has a non-zero delegation fee
-        assert!(ava_labs_node.delegation_fee > 0.0);
+        assert!(ava_labs_node.delegation_fee > Some(0.0));
     }
 }

--- a/crates/ash_sdk/src/avalanche/nodes.rs
+++ b/crates/ash_sdk/src/avalanche/nodes.rs
@@ -3,10 +3,7 @@
 
 // Module that contains code to interact with Avalanche nodes
 
-use crate::{
-    avalanche::{avalanche_node_id_from_string, jsonrpc::info::*},
-    errors::*,
-};
+use crate::{avalanche::jsonrpc::info::*, errors::*};
 use avalanche_types::{ids::node::Id, jsonrpc::info::VmVersions};
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +11,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AvalancheNode {
-    #[serde(deserialize_with = "avalanche_node_id_from_string")]
     pub id: Id,
     pub http_host: String,
     pub http_port: u16,

--- a/crates/ash_sdk/src/avalanche/nodes.rs
+++ b/crates/ash_sdk/src/avalanche/nodes.rs
@@ -3,8 +3,10 @@
 
 // Module that contains code to interact with Avalanche nodes
 
-use crate::avalanche::{avalanche_node_id_from_string, jsonrpc::info::*};
-use crate::errors::*;
+use crate::{
+    avalanche::{avalanche_node_id_from_string, jsonrpc::info::*},
+    errors::*,
+};
 use avalanche_types::{ids::node::Id, jsonrpc::info::VmVersions};
 use serde::{Deserialize, Serialize};
 

--- a/crates/ash_sdk/src/errors.rs
+++ b/crates/ash_sdk/src/errors.rs
@@ -53,12 +53,20 @@ pub enum RpcError {
         target_value: String,
         msg: String,
     },
+    #[error("RPC response contains an error: code {code}, message: {message}, data: {data:?}")]
+    ResponseError {
+        code: i32,
+        message: String,
+        data: Option<String>,
+    },
     #[error("failed to call {function_name} on '{contract_addr}': {msg}")]
     EthCallFailure {
         contract_addr: String,
         function_name: String,
         msg: String,
     },
+    #[error("unknown RPC error: {0}")]
+    Unknown(String),
 }
 
 #[derive(Error, Debug)]

--- a/crates/ash_sdk/src/protocol.rs
+++ b/crates/ash_sdk/src/protocol.rs
@@ -8,8 +8,10 @@ pub mod nodes;
 
 use crate::avalanche::AvalancheNetwork;
 use crate::errors::*;
-use crate::protocol::contracts::{ash_router_http::AshRouterHttp, AshContractMetadata};
-use crate::protocol::nodes::AshNode;
+use crate::protocol::{
+    contracts::{ash_router_http::AshRouterHttp, AshContractMetadata},
+    nodes::AshNode,
+};
 use serde::Serialize;
 
 /// Ash protocol entities

--- a/crates/ash_sdk/tests/conf/custom.yml
+++ b/crates/ash_sdk/tests/conf/custom.yml
@@ -6,8 +6,6 @@ avalancheNetworks:
   - name: custom
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain

--- a/crates/ash_sdk/tests/conf/quicknode.yml
+++ b/crates/ash_sdk/tests/conf/quicknode.yml
@@ -6,8 +6,6 @@ avalancheNetworks:
   - name: fuji
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain

--- a/crates/ash_sdk/tests/conf/wrong.yml
+++ b/crates/ash_sdk/tests/conf/wrong.yml
@@ -6,8 +6,6 @@ avalancheNetworks:
   - name: no-primary-network
     subnets:
       - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: 2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm
             name: MyChain
@@ -16,8 +14,6 @@ avalancheNetworks:
   - name: no-pchain
     subnets:
       - id: 11111111111111111111111111111111LpoYY
-        controlKeys: []
-        threshold: 0
         blockchains:
           - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
             name: C-Chain


### PR DESCRIPTION
### Linked issues

- Fixes #18 

### Dependencies

- https://github.com/ava-labs/avalanche-types-rs/pull/36

### Changes

- _(sdk)_ Use `avalanche_types` structs to deserialize the response from:
  - `platform.getSubnets`: `Subnet`
  - `platform.getBlockchains`: `Blockchain`
  - `platform.getCurrentValidators`: `ApiPrimaryValidator`, `ApiPrimaryDelegator`, and `ApiOwner`
  
  Previously we were using custom implementations
- _(sdk)_ Implement `From` as suggested in #18 for the structs impacted
- _(sdk)_ Add the `get_json_rpc_req_result` method as a generic way of posting a JSON RPC request and getting the result. For that, I had to create the `JsonRpcResponse<Resp, Res>` trait and the `impl_json_rpc_response` macro.
- _(cli)_ Make templating cleaner for validators' info

### Additional comments

:warning: For now I am pointing to our fork of `avalanche-types-rs` until the PR is merged.
