### PR TITLE
Enrich Avalanche nodes info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Start a local Avalanche network
         run: ~/bin/avalanche network start
 
+      - name: Setup cache for Rust
+        uses: Swatinem/rust-cache@v2
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Template tests config file
         run: |
           envsubst < crates/ash_sdk/tests/conf/quicknode.yml > ${{ runner.temp }}/ash-test-avax-conf.yml

--- a/crates/ash_cli/src/avalanche/network.rs
+++ b/crates/ash_cli/src/avalanche/network.rs
@@ -16,7 +16,7 @@ pub(crate) struct NetworkCommand {
 
 #[derive(Subcommand)]
 enum NetworkSubcommands {
-    #[command(about = "List Avalanche networks")]
+    #[command(about = "List known Avalanche networks")]
     List,
 }
 

--- a/crates/ash_cli/src/avalanche/node.rs
+++ b/crates/ash_cli/src/avalanche/node.rs
@@ -3,13 +3,9 @@
 
 // Module that contains the node subcommand parser
 
-use crate::utils::{
-    error::CliError,
-    templating::{template_avalanche_node_info, type_colorize},
-};
+use crate::utils::{error::CliError, templating::*};
 use ash_sdk::avalanche::nodes::AvalancheNode;
 use clap::{Parser, Subcommand};
-use colored::Colorize;
 
 #[derive(Parser)]
 #[command(about = "Interact with Avalanche nodes")]
@@ -86,23 +82,10 @@ fn is_bootstrapped(
         return Ok(());
     }
 
-    if is_bootstrapped {
-        println!(
-            "Chain '{}' on node '{}:{}': {}",
-            type_colorize(&chain),
-            type_colorize(&node.http_host),
-            type_colorize(&node.http_port),
-            "Bootstrapped ✓".green(),
-        );
-    } else {
-        println!(
-            "Chain '{}' on node '{}:{}': {}",
-            type_colorize(&chain),
-            type_colorize(&node.http_host),
-            type_colorize(&node.http_port),
-            "Not yet bootstrapped ✗".red(),
-        );
-    }
+    println!(
+        "{}",
+        template_chain_is_bootstrapped(&node, chain, is_bootstrapped, 0)
+    );
 
     Ok(())
 }

--- a/crates/ash_cli/src/avalanche/node.rs
+++ b/crates/ash_cli/src/avalanche/node.rs
@@ -3,29 +3,38 @@
 
 // Module that contains the node subcommand parser
 
-use crate::utils::{error::CliError, templating::template_avalanche_node_info};
+use crate::utils::{
+    error::CliError,
+    templating::{template_avalanche_node_info, type_colorize},
+};
 use ash_sdk::avalanche::nodes::AvalancheNode;
 use clap::{Parser, Subcommand};
+use colored::Colorize;
 
 #[derive(Parser)]
 #[command(about = "Interact with Avalanche nodes")]
 pub(crate) struct NodeCommand {
     #[command(subcommand)]
     command: NodeSubcommands,
+    #[arg(
+        long,
+        default_value = "127.0.0.1",
+        help = "Node's HTTP host (IP address or FQDN)",
+        global = true
+    )]
+    http_host: String,
+    #[arg(long, default_value = "9650", help = "Node's HTTP port", global = true)]
+    http_port: u16,
 }
 
 #[derive(Subcommand)]
 enum NodeSubcommands {
-    #[command(about = "Show Avalanche node information")]
-    Info {
-        #[arg(
-            long,
-            default_value = "127.0.0.1",
-            help = "Node's HTTP host (IP address or FQDN)"
-        )]
-        http_host: String,
-        #[arg(long, default_value = "9650", help = "Node's HTTP port")]
-        http_port: u16,
+    #[command(about = "Show node information")]
+    Info,
+    #[command(about = "Check if a chain is done bootstrapping on the node")]
+    IsBootstrapped {
+        #[arg(long, help = "Chain ID or alias")]
+        chain: String,
     },
 }
 
@@ -56,12 +65,54 @@ fn info(http_host: &str, http_port: u16, json: bool) -> Result<(), CliError> {
     Ok(())
 }
 
+fn is_bootstrapped(
+    http_host: &str,
+    http_port: u16,
+    chain: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    let node = AvalancheNode {
+        http_host: http_host.to_string(),
+        http_port,
+        ..Default::default()
+    };
+
+    let is_bootstrapped = node
+        .check_chain_bootstrapping(chain)
+        .map_err(|e| CliError::dataerr(format!("Error checking if chain is bootstrapped: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::to_string(&is_bootstrapped).unwrap());
+        return Ok(());
+    }
+
+    if is_bootstrapped {
+        println!(
+            "Chain '{}' on node '{}:{}': {}",
+            type_colorize(&chain),
+            type_colorize(&node.http_host),
+            type_colorize(&node.http_port),
+            "Bootstrapped ✓".green(),
+        );
+    } else {
+        println!(
+            "Chain '{}' on node '{}:{}': {}",
+            type_colorize(&chain),
+            type_colorize(&node.http_host),
+            type_colorize(&node.http_port),
+            "Not yet bootstrapped ✗".red(),
+        );
+    }
+
+    Ok(())
+}
+
 // Parse node subcommand
 pub(crate) fn parse(node: NodeCommand, json: bool) -> Result<(), CliError> {
     match node.command {
-        NodeSubcommands::Info {
-            http_host,
-            http_port,
-        } => info(&http_host, http_port, json),
+        NodeSubcommands::Info => info(&node.http_host, node.http_port, json),
+        NodeSubcommands::IsBootstrapped { chain } => {
+            is_bootstrapped(&node.http_host, node.http_port, &chain, json)
+        }
     }
 }

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -254,8 +254,9 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: u8) -> 
         "
         Node '{}:{}':
           ID:            {}
+          Network:       {}
           Public IP:     {}
-          Stacking port: {}
+          Staking port:  {}
           Versions:
             AvalancheGo: {}
             Database:    {}
@@ -264,12 +265,13 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: u8) -> 
               AVM:        {}
               EVM:        {}
               PlatformVM: {}
-            Uptime:
-              Rewarding stake:  {}%
-              Weighted average: {}%",
+          Uptime:
+            Rewarding stake:  {}%
+            Weighted average: {}%",
         type_colorize(&node.http_host),
         type_colorize(&node.http_port),
         type_colorize(&node.id),
+        type_colorize(&node.network),
         type_colorize(&node.public_ip),
         type_colorize(&node.staking_port),
         type_colorize(&node.versions.avalanchego_version),

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -27,7 +27,7 @@ where
         "String" => var.to_string().yellow(),
         "&u64" | "&u32" | "&u16" | "&u8" | "&usize" => var.to_string().cyan(),
         "&i64" | "&i32" | "&i16" | "&i8" | "&isize" => var.to_string().cyan(),
-        "&f64" | "&f32" => var.to_string().magenta(),
+        "&f64" | "&f32" | "IpAddr" => var.to_string().magenta(),
         "&bool" => var.to_string().blue(),
         "Id" => var.to_string().green(),
         _ => var.to_string().bright_white(),

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -285,3 +285,25 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: u8) -> 
 
     indent::indent_all_by(indent.into(), info)
 }
+
+pub(crate) fn template_chain_is_bootstrapped(
+    node: &AvalancheNode,
+    chain: &str,
+    is_bootstrapped: bool,
+    indent: u8,
+) -> String {
+    let mut info = String::new();
+
+    info.push_str(&formatdoc!(
+        "Chain '{}' on node '{}:{}': {}",
+        type_colorize(&chain),
+        type_colorize(&node.http_host),
+        type_colorize(&node.http_port),
+        match is_bootstrapped {
+            true => "Bootstrapped ✓".green(),
+            false => "Not yet bootstrapped ✗".red(),
+        }
+    ));
+
+    indent::indent_all_by(indent.into(), info)
+}

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -24,7 +24,7 @@ where
     T: std::fmt::Display,
 {
     match type_of(var).split(':').last().unwrap() {
-        "String" => var.to_string().yellow(),
+        "String" | "&&str" => var.to_string().yellow(),
         "&u64" | "&u32" | "&u16" | "&u8" | "&usize" => var.to_string().cyan(),
         "&i64" | "&i32" | "&i16" | "&i8" | "&isize" => var.to_string().cyan(),
         "&f64" | "&f32" | "IpAddr" => var.to_string().magenta(),
@@ -152,8 +152,7 @@ pub(crate) fn template_validator_info(
         } else {
             info.push_str(&formatdoc!(
                 "
-            - {}
-            ",
+            - {}",
                 type_colorize(&validator.node_id),
             ));
         }

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -23,6 +23,7 @@ impl_json_rpc_response!(GetNodeIpResponse, GetNodeIpResult);
 impl_json_rpc_response!(GetNodeVersionResponse, GetNodeVersionResult);
 impl_json_rpc_response!(UptimeResponse, UptimeResult);
 impl_json_rpc_response!(GetNetworkNameResponse, GetNetworkNameResult);
+impl_json_rpc_response!(IsBootstrappedResponse, IsBootstrappedResult);
 
 /// Get the ID of a node by querying the Info API
 pub fn get_node_id(rpc_url: &str) -> Result<Id, RpcError> {
@@ -79,6 +80,21 @@ pub fn get_network_name(rpc_url: &str) -> Result<String, RpcError> {
     .network_name;
 
     Ok(network_name)
+}
+
+/// Check if a given chain is done boostrapping by querying the Info API
+/// `chain` is the chain ID or alias of the chain to check
+pub fn is_bootstrapped(rpc_url: &str, chain: &str) -> Result<bool, RpcError> {
+    let is_bootstrapped = get_json_rpc_req_result::<IsBootstrappedResponse, IsBootstrappedResult>(
+        rpc_url,
+        "info.isBootstrapped",
+        Some(ureq::json!({
+            "chain": chain.to_string()
+        })),
+    )?
+    .is_bootstrapped;
+
+    Ok(is_bootstrapped)
 }
 
 #[cfg(test)]

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -20,6 +20,8 @@ pub const AVAX_INFO_API_ENDPOINT: &str = "ext/info";
 
 impl_json_rpc_response!(GetNodeIdResponse, GetNodeIdResult);
 impl_json_rpc_response!(GetNodeIpResponse, GetNodeIpResult);
+impl_json_rpc_response!(GetNodeVersionResponse, GetNodeVersionResult);
+impl_json_rpc_response!(UptimeResponse, UptimeResult);
 
 // Get the ID of a node by querying the Info API
 pub fn get_node_id(rpc_url: &str) -> Result<Id, RpcError> {
@@ -46,41 +48,24 @@ pub fn get_node_ip(rpc_url: &str) -> Result<SocketAddr, RpcError> {
 }
 
 // Get the version of a node by querying the Info API
-pub fn get_node_version(rpc_url: &str) -> Result<AvalancheNodeVersions, ureq::Error> {
-    let resp: GetNodeVersionResponse = ureq::post(rpc_url)
-        .send_json(ureq::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "info.getNodeVersion",
-            "params": {}
-        }))?
-        .into_json()?;
+pub fn get_node_version(rpc_url: &str) -> Result<AvalancheNodeVersions, RpcError> {
+    let node_version = get_json_rpc_req_result::<GetNodeVersionResponse, GetNodeVersionResult>(
+        rpc_url,
+        "info.getNodeVersion",
+        None,
+    )?
+    .into();
 
-    let node_version = resp.result.unwrap();
-    Ok(AvalancheNodeVersions {
-        avalanchego_version: node_version.version,
-        database_version: node_version.database_version,
-        git_commit: node_version.git_commit,
-        vm_versions: node_version.vm_versions,
-    })
+    Ok(node_version)
 }
 
 // Get the uptime of a node by querying the Info API
-pub fn get_node_uptime(rpc_url: &str) -> Result<AvalancheNodeUptime, ureq::Error> {
-    let resp: UptimeResponse = ureq::post(rpc_url)
-        .send_json(ureq::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "info.uptime",
-            "params": {}
-        }))?
-        .into_json()?;
+pub fn get_node_uptime(rpc_url: &str) -> Result<AvalancheNodeUptime, RpcError> {
+    let uptime =
+        get_json_rpc_req_result::<UptimeResponse, UptimeResult>(rpc_url, "info.uptime", None)?
+            .into();
 
-    let node_uptime = resp.result.unwrap();
-    Ok(AvalancheNodeUptime {
-        rewarding_stake_percentage: node_uptime.rewarding_stake_percentage,
-        weighted_average_percentage: node_uptime.weighted_average_percentage,
-    })
+    Ok(uptime)
 }
 
 #[cfg(test)]

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -22,8 +22,9 @@ impl_json_rpc_response!(GetNodeIdResponse, GetNodeIdResult);
 impl_json_rpc_response!(GetNodeIpResponse, GetNodeIpResult);
 impl_json_rpc_response!(GetNodeVersionResponse, GetNodeVersionResult);
 impl_json_rpc_response!(UptimeResponse, UptimeResult);
+impl_json_rpc_response!(GetNetworkNameResponse, GetNetworkNameResult);
 
-// Get the ID of a node by querying the Info API
+/// Get the ID of a node by querying the Info API
 pub fn get_node_id(rpc_url: &str) -> Result<Id, RpcError> {
     let node_id = get_json_rpc_req_result::<GetNodeIdResponse, GetNodeIdResult>(
         rpc_url,
@@ -35,7 +36,7 @@ pub fn get_node_id(rpc_url: &str) -> Result<Id, RpcError> {
     Ok(node_id)
 }
 
-// Get the IP of a node by querying the Info API
+/// Get the IP of a node by querying the Info API
 pub fn get_node_ip(rpc_url: &str) -> Result<SocketAddr, RpcError> {
     let ip = get_json_rpc_req_result::<GetNodeIpResponse, GetNodeIpResult>(
         rpc_url,
@@ -47,7 +48,7 @@ pub fn get_node_ip(rpc_url: &str) -> Result<SocketAddr, RpcError> {
     Ok(ip)
 }
 
-// Get the version of a node by querying the Info API
+/// Get the version of a node by querying the Info API
 pub fn get_node_version(rpc_url: &str) -> Result<AvalancheNodeVersions, RpcError> {
     let node_version = get_json_rpc_req_result::<GetNodeVersionResponse, GetNodeVersionResult>(
         rpc_url,
@@ -59,13 +60,25 @@ pub fn get_node_version(rpc_url: &str) -> Result<AvalancheNodeVersions, RpcError
     Ok(node_version)
 }
 
-// Get the uptime of a node by querying the Info API
+/// Get the uptime of a node by querying the Info API
 pub fn get_node_uptime(rpc_url: &str) -> Result<AvalancheNodeUptime, RpcError> {
     let uptime =
         get_json_rpc_req_result::<UptimeResponse, UptimeResult>(rpc_url, "info.uptime", None)?
             .into();
 
     Ok(uptime)
+}
+
+/// Get the name of the network a node is participating in by querying the Info API
+pub fn get_network_name(rpc_url: &str) -> Result<String, RpcError> {
+    let network_name = get_json_rpc_req_result::<GetNetworkNameResponse, GetNetworkNameResult>(
+        rpc_url,
+        "info.getNetworkName",
+        None,
+    )?
+    .network_name;
+
+    Ok(network_name)
 }
 
 #[cfg(test)]

--- a/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
@@ -26,7 +26,7 @@ impl_json_rpc_response!(GetSubnetsResponse, GetSubnetsResult);
 impl_json_rpc_response!(GetBlockchainsResponse, GetBlockchainsResult);
 impl_json_rpc_response!(GetCurrentValidatorsResponse, GetCurrentValidatorsResult);
 
-// Get the Subnets of the network by querying the P-Chain API
+/// Get the Subnets of the network by querying the P-Chain API
 pub fn get_network_subnets(
     rpc_url: &str,
     network_name: &str,
@@ -50,7 +50,7 @@ pub fn get_network_subnets(
     Ok(network_subnets)
 }
 
-// Get the blockchains of the network by querying the P-Chain API
+/// Get the blockchains of the network by querying the P-Chain API
 pub fn get_network_blockchains(
     rpc_url: &str,
     network_name: &str,
@@ -73,7 +73,7 @@ pub fn get_network_blockchains(
     Ok(network_blockchains)
 }
 
-// Get the current validators of a Subnet by querying the P-Chain API
+/// Get the current validators of a Subnet by querying the P-Chain API
 pub fn get_current_validators(
     rpc_url: &str,
     subnet_id: &str,

--- a/crates/ash_sdk/src/avalanche/nodes.rs
+++ b/crates/ash_sdk/src/avalanche/nodes.rs
@@ -27,12 +27,6 @@ pub struct AvalancheNode {
 
 impl Default for AvalancheNode {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl AvalancheNode {
-    pub fn default() -> Self {
         Self {
             id: Id::default(),
             http_host: String::from("127.0.0.1"),
@@ -44,7 +38,9 @@ impl AvalancheNode {
             network: String::from("local"),
         }
     }
+}
 
+impl AvalancheNode {
     /// Update the node's information
     pub fn update_info(&mut self) -> Result<(), AshError> {
         let node_host = format!("{}:{}", self.http_host, self.http_port);
@@ -98,7 +94,7 @@ impl AvalancheNode {
                         return Err(AshError::RpcError(RpcError::GetFailure {
                             data_type: "uptime".to_string(),
                             target_type: "node".to_string(),
-                            target_value: node_host.to_string(),
+                            target_value: node_host,
                             msg: format!(
                                 "{:?}",
                                 RpcError::ResponseError {
@@ -114,7 +110,7 @@ impl AvalancheNode {
                     return Err(AshError::RpcError(RpcError::GetFailure {
                         data_type: "uptime".to_string(),
                         target_type: "node".to_string(),
-                        target_value: node_host.to_string(),
+                        target_value: node_host,
                         msg: e.to_string(),
                     }));
                 }

--- a/crates/ash_sdk/src/avalanche/nodes.rs
+++ b/crates/ash_sdk/src/avalanche/nodes.rs
@@ -16,6 +16,7 @@ use std::net::{IpAddr, Ipv4Addr};
 #[serde(rename_all = "camelCase")]
 pub struct AvalancheNode {
     pub id: Id,
+    pub network: String,
     pub http_host: String,
     pub http_port: u16,
     pub public_ip: IpAddr,
@@ -40,6 +41,7 @@ impl AvalancheNode {
             staking_port: 9651,
             versions: AvalancheNodeVersions::default(),
             uptime: AvalancheNodeUptime::default(),
+            network: String::from("local"),
         }
     }
 
@@ -67,6 +69,13 @@ impl AvalancheNode {
 
         self.versions = get_node_version(&api_path).map_err(|e| RpcError::GetFailure {
             data_type: "version".to_string(),
+            target_type: "node".to_string(),
+            target_value: node_host.to_string(),
+            msg: e.to_string(),
+        })?;
+
+        self.network = get_network_name(&api_path).map_err(|e| RpcError::GetFailure {
+            data_type: "network".to_string(),
             target_type: "node".to_string(),
             target_value: node_host.to_string(),
             msg: e.to_string(),
@@ -165,6 +174,7 @@ mod tests {
     const ASH_TEST_HTTP_HOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     const ASH_TEST_STACKING_PORT: u16 = 9651;
     const ASH_TEST_NODE_ID: &str = "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg";
+    const ASH_TEST_NETWORK_NAME: &str = "network-1337";
 
     #[test]
     #[ignore]
@@ -181,8 +191,9 @@ mod tests {
 
         node.update_info().unwrap();
 
-        // Test the node id, public_ip and stacking_port
+        // Test the node ID, network, public_ip and stacking_port
         assert_eq!(node.id.to_string(), ASH_TEST_NODE_ID);
+        assert_eq!(node.network, ASH_TEST_NETWORK_NAME);
         assert_eq!(node.public_ip, ASH_TEST_HTTP_HOST);
         assert_eq!(node.staking_port, ASH_TEST_STACKING_PORT);
 


### PR DESCRIPTION
### Linked issues

- Fixes #32
- Fixes #39
- Fixes #40 

### Changes

- `ash_sdk`
  - Use `get_json_rpc_req_result` for all JSON RPC API calls
  - Add `get_network_name()` and `is_bootstrapped()` functions in `jsonrpc::info` module
  - Store node `public_ip` as `IpAddr` instead of `String`
  - Avoid `AvalancheNode.update_info()` failing if the `info.uptime` endpoint returns an error because the node is not a validator
- `ash_cli`
  - Add `avalanche node is-bootstrapped` command
  - Fix prints templating
- CI
  - Enable cache in Actions workflows using `Swatinem/rust-cache@v2`

### Additional comments

Still using our fork of `avalanche-types-rs`
