### PR TITLE
Add Subnet type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "async-std",
  "avalanche-types",
  "config",
+ "enum-display-derive",
  "ethers",
  "hex",
  "regex",
@@ -1483,6 +1484,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-display-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ef37b2a9b242295d61a154ee91ae884afff6b8b933b486b12481cc58310ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avalanche-types"
 version = "0.0.379"
-source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=update-info-jsonrpc-responses#c0bae5724ad635de0dc4656deac915c581123a74"
+source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=update-info-jsonrpc-responses#b94fae0ddb0989672e9df797ff10c84230f0cc6d"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avalanche-types"
 version = "0.0.379"
-source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=update-info-jsonrpc-responses#b94fae0ddb0989672e9df797ff10c84230f0cc6d"
+source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=update-info-jsonrpc-responses#7fd5106b55e86e1046ff665b0b43ab5122f59cb9"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",
@@ -408,7 +408,7 @@ dependencies = [
  "cert-manager",
  "chrono",
  "cmp-manager",
- "ecdsa 0.16.6",
+ "ecdsa 0.16.7",
  "ethers-core 2.0.4",
  "hex",
  "hmac",
@@ -636,9 +636,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "byte-slice-cast"
@@ -849,7 +849,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -872,16 +872,6 @@ name = "cmp-manager"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f5e2b424191b35b798b06e6c67fa5a5440a098925d931d7e91511d7d8fe275"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
 
 [[package]]
 name = "coins-bip32"
@@ -1170,50 +1160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,7 +1180,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1245,7 +1191,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1377,7 +1323,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1406,15 +1352,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der 0.7.5",
  "digest 0.10.6",
  "elliptic-curve 0.13.4",
  "rfc6979 0.4.0",
  "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -2075,7 +2022,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2198,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -2387,12 +2334,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -2566,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2604,7 +2550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.6",
+ "ecdsa 0.16.7",
  "elliptic-curve 0.13.4",
  "once_cell",
  "sha2 0.10.6",
@@ -2680,15 +2626,6 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -2906,7 +2843,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2990,7 +2927,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3196,7 +3133,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3276,22 +3213,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3443,9 +3380,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -4035,12 +3972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "scrypt"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4092,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4105,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4130,9 +4061,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -4150,13 +4081,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4207,7 +4138,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4487,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4580,7 +4511,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4656,9 +4587,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4681,7 +4612,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4800,14 +4731,14 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
@@ -5038,9 +4969,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5048,24 +4979,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5075,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5085,22 +5016,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "wasm-timer"
@@ -5119,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5488,7 +5419,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/crates/ash_cli/src/avalanche/network.rs
+++ b/crates/ash_cli/src/avalanche/network.rs
@@ -41,6 +41,7 @@ fn list(config: Option<&str>, json: bool) -> Result<(), CliError> {
     for network in networks {
         println!("  - '{}'", type_colorize(&network.name));
     }
+
     Ok(())
 }
 

--- a/crates/ash_cli/src/avalanche/subnet.rs
+++ b/crates/ash_cli/src/avalanche/subnet.rs
@@ -51,6 +51,7 @@ fn list(network_name: &str, config: Option<&str>, json: bool) -> Result<(), CliE
     for subnet in network.subnets.iter() {
         println!("{}", template_subnet_info(subnet, true, 0));
     }
+
     Ok(())
 }
 
@@ -69,6 +70,7 @@ fn info(network_name: &str, id: &str, config: Option<&str>, json: bool) -> Resul
     }
 
     println!("{}", template_subnet_info(subnet, false, 0));
+
     Ok(())
 }
 

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -63,12 +63,16 @@ fn list(
 
     println!(
         "Found {} validator(s) on Subnet '{}':",
-        subnet.validators.len(),
-        subnet_id
+        type_colorize(&subnet.validators.len()),
+        type_colorize(&subnet_id)
     );
     for validator in subnet.validators.iter() {
-        println!("{}", template_validator_info(validator, true, 2, true));
+        println!(
+            "{}",
+            template_validator_info(validator, subnet, true, 2, true)
+        );
     }
+
     Ok(())
 }
 
@@ -95,8 +99,11 @@ fn info(
         println!("{}", serde_json::to_string(&validator).unwrap());
         return Ok(());
     }
+    println!(
+        "{}",
+        template_validator_info(validator, subnet, false, 0, true)
+    );
 
-    println!("{}", template_validator_info(validator, false, 0, true));
     Ok(())
 }
 

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -29,6 +29,7 @@ async-std = { version = "1.10.0", features = ["attributes", "tokio1"] }
 # reqwest is used by ethers
 # We need to enable the rustls-tls-native-roots feature to support self-signed certificates
 reqwest = { version = "0.11.14", features = ["rustls-tls-native-roots"] }
+enum-display-derive = "0.1.1"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/crates/ash_sdk/conf/default.yml
+++ b/crates/ash_sdk/conf/default.yml
@@ -6,6 +6,7 @@ avalancheNetworks:
   - name: mainnet
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -24,6 +25,7 @@ avalancheNetworks:
   - name: fuji
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -42,6 +44,7 @@ avalancheNetworks:
   - name: mainnet-ankr
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -60,6 +63,7 @@ avalancheNetworks:
   - name: fuji-ankr
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -78,6 +82,7 @@ avalancheNetworks:
   - name: mainnet-blast
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
@@ -96,6 +101,7 @@ avalancheNetworks:
   - name: fuji-blast
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain

--- a/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
@@ -177,7 +177,7 @@ mod tests {
         // Test that the node is connected
         assert!(ava_labs_node.connected);
         // Test that the node has a non-zero uptime
-        assert!(ava_labs_node.uptime > 0.0);
+        assert!(ava_labs_node.uptime > Some(0.0));
         // Test that the node has a non-zero weight
         assert!(ava_labs_node.weight > Some(0));
         // Test that the node has a non-zero potential reward

--- a/crates/ash_sdk/src/avalanche/subnets.rs
+++ b/crates/ash_sdk/src/avalanche/subnets.rs
@@ -3,7 +3,9 @@
 
 // Module that contains code to interact with Avalanche Subnets and validators
 
-use crate::avalanche::{blockchains::AvalancheBlockchain, AvalancheOutputOwners};
+use crate::avalanche::{
+    blockchains::AvalancheBlockchain, AvalancheOutputOwners, AVAX_PRIMARY_NETWORK_ID,
+};
 use crate::errors::*;
 use avalanche_types::{
     ids::{node::Id as NodeId, Id},
@@ -11,11 +13,23 @@ use avalanche_types::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Avalanche Subnet types
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub enum AvalancheSubnetType {
+    PrimaryNetwork,
+    #[default]
+    Permissioned,
+    /// Also named "PoS" in the Avalanche documentation
+    Elastic,
+}
+
 /// Avalanche Subnet
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AvalancheSubnet {
     pub id: Id,
+    #[serde(default)]
+    pub subnet_type: AvalancheSubnetType,
     // TODO: store control keys as ShortIds
     #[serde(default)]
     pub control_keys: Vec<String>,
@@ -79,6 +93,16 @@ impl From<Subnet> for AvalancheSubnet {
     fn from(subnet: Subnet) -> Self {
         Self {
             id: subnet.id,
+            // Based on Avalanche documentation at https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetsubnets
+            // "If the Subnet is a PoS (= elastic) Subnet, then threshold will be 0 and controlKeys will be empty."
+            // The Primary Network is an elastic Subnet and its ID is hardcoded
+            subnet_type: match subnet.threshold {
+                0 => match subnet.id.to_string().as_str() {
+                    AVAX_PRIMARY_NETWORK_ID => AvalancheSubnetType::PrimaryNetwork,
+                    _ => AvalancheSubnetType::Elastic,
+                },
+                _ => AvalancheSubnetType::Permissioned,
+            },
             control_keys: subnet
                 .control_keys
                 .map(|keys| {
@@ -110,7 +134,7 @@ pub struct AvalancheSubnetValidator {
     pub potential_reward: Option<u64>,
     pub delegation_fee: Option<f32>,
     pub connected: bool,
-    pub uptime: f32,
+    pub uptime: Option<f32>,
     pub validation_reward_owner: Option<AvalancheOutputOwners>,
     pub delegator_count: Option<u64>,
     pub delegator_weight: Option<u64>,

--- a/crates/ash_sdk/src/avalanche/subnets.rs
+++ b/crates/ash_sdk/src/avalanche/subnets.rs
@@ -12,9 +12,10 @@ use avalanche_types::{
     jsonrpc::platformvm::{ApiPrimaryDelegator, ApiPrimaryValidator, Subnet},
 };
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 /// Avalanche Subnet types
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Display, Clone, Serialize, Deserialize)]
 pub enum AvalancheSubnetType {
     PrimaryNetwork,
     #[default]

--- a/crates/ash_sdk/src/lib.rs
+++ b/crates/ash_sdk/src/lib.rs
@@ -4,3 +4,6 @@
 pub mod avalanche;
 pub mod conf;
 pub mod errors;
+
+#[macro_use]
+extern crate enum_display_derive;

--- a/crates/ash_sdk/tests/conf/custom.yml
+++ b/crates/ash_sdk/tests/conf/custom.yml
@@ -6,6 +6,7 @@ avalancheNetworks:
   - name: custom
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain

--- a/crates/ash_sdk/tests/conf/quicknode.yml
+++ b/crates/ash_sdk/tests/conf/quicknode.yml
@@ -6,6 +6,7 @@ avalancheNetworks:
   - name: fuji
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain

--- a/crates/ash_sdk/tests/conf/wrong.yml
+++ b/crates/ash_sdk/tests/conf/wrong.yml
@@ -6,6 +6,7 @@ avalancheNetworks:
   - name: no-primary-network
     subnets:
       - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
+        subnetType: Permissioned
         blockchains:
           - id: 2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm
             name: MyChain
@@ -14,6 +15,7 @@ avalancheNetworks:
   - name: no-pchain
     subnets:
       - id: 11111111111111111111111111111111LpoYY
+        subnetType: PrimaryNetwork
         blockchains:
           - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
             name: C-Chain


### PR DESCRIPTION
### Linked issues

- Fixes #42

### Changes

- `ash_sdk`
  - Fix `uptime` field (see https://github.com/ava-labs/avalanche-types-rs/pull/72)
  - Add the `subnet_type` field to `AvalancheSubnetValidator` which uses the `AvalancheSubnetType` enum
  - Add the `https_enabled` field to `AvalancheNode`
- `ash_cli`
  - Improve output templating based on Subnet type
  - Add the `--https` flag for all `node` subcommands

### Additional comments

Still using our fork of `avalanche-types-rs`
