### PR TITLE
Fetch pending validators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install avalanche-cli
         run: |
-          curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh | sh -s
+          curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh | sh -s -- v1.2.1
 
       - name: Start a local Avalanche network
         run: ~/bin/avalanche network start

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,14 +410,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avalanche-types"
-version = "0.0.386"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5898e85a263bd0df936c7c432c35c0b013dfb564c0dd6ac216a8ebd9ce10fae8"
+version = "0.0.393"
+source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=70-vm-versions-hashmap#f0409a69857c372b8647d63e44f00d138a637bbe"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",
  "blst",
- "bs58",
+ "bs58 0.5.0",
  "bytes",
  "cert-manager",
  "chrono",
@@ -688,6 +687,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "sha2 0.10.6",
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634c509653de24b439672164bbf56f5f582a2ab0e313d3b0f6af0b7345cf2560"
 dependencies = [
  "bincode",
- "bs58",
+ "bs58 0.4.0",
  "coins-core",
  "digest 0.10.7",
  "getrandom",
@@ -3570,7 +3579,7 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2557c07161d4d805cd7e711d0648b292be9e727d9678d078bab052278cd1b71"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "lazy_static",
  "primitive-types",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2934,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.53"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ categories = [
 	"data-structures",
 ]
 keywords = ["blockchain", "avalanche", "subnets", "ash"]
+
+[patch.crates-io]
+avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "70-vm-versions-hashmap" }

--- a/crates/ash_cli/src/avalanche.rs
+++ b/crates/ash_cli/src/avalanche.rs
@@ -64,6 +64,17 @@ fn update_subnet_validators(
     Ok(())
 }
 
+// Update a Subnet's pending validators
+fn update_subnet_pending_validators(
+    network: &mut AvalancheNetwork,
+    subnet_id: &str,
+) -> Result<(), CliError> {
+    network
+        .update_subnet_pending_validators(parse_id(subnet_id)?)
+        .map_err(|e| CliError::dataerr(format!("Error updating pending validators: {e}")))?;
+    Ok(())
+}
+
 // Parse avalanche subcommand
 pub(crate) fn parse(
     avalanche: AvalancheCommand,

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -107,7 +107,7 @@ fn list(
             validators = subnet.pending_validators.clone();
             first_line = format!(
                 "Found {} pending validator(s) on Subnet '{}':",
-                type_colorize(&subnet.validators.len()),
+                type_colorize(&subnet.pending_validators.len()),
                 type_colorize(&subnet_id)
             )
         }

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -43,7 +43,7 @@ enum ValidatorSubcommands {
     Add {
         /// Validator NodeID
         id: String,
-        /// Validator weight (permissioned Subnet) or stake in AVAX (elastic Subnets)
+        /// Validator weight (permissioned Subnet) or stake in AVAX (elastic Subnet)
         stake_or_weight: u64,
         /// Start time of the validation (YYYY-MM-DDTHH:MM:SSZ)
         #[arg(long, short = 'S')]
@@ -71,7 +71,11 @@ enum ValidatorSubcommands {
     },
     /// List the Subnet's validators
     #[command()]
-    List,
+    List {
+        /// List pending validators
+        #[arg(long, short = 'p')]
+        pending: bool,
+    },
     /// Show validator information
     #[command()]
     Info {
@@ -84,28 +88,50 @@ enum ValidatorSubcommands {
 fn list(
     network_name: &str,
     subnet_id: &str,
+    pending: bool,
     config: Option<&str>,
     json: bool,
 ) -> Result<(), CliError> {
     let mut network = load_network(network_name, config)?;
     update_network_subnets(&mut network)?;
-    update_subnet_validators(&mut network, subnet_id)?;
+    let subnet;
+    let validators;
+    let first_line;
 
-    let subnet = network
-        .get_subnet(parse_id(subnet_id)?)
-        .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
+    match pending {
+        true => {
+            update_subnet_pending_validators(&mut network, subnet_id)?;
+            subnet = network
+                .get_subnet(parse_id(subnet_id)?)
+                .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
+            validators = subnet.pending_validators.clone();
+            first_line = format!(
+                "Found {} pending validator(s) on Subnet '{}':",
+                type_colorize(&subnet.validators.len()),
+                type_colorize(&subnet_id)
+            )
+        }
+        false => {
+            update_subnet_validators(&mut network, subnet_id)?;
+            subnet = network
+                .get_subnet(parse_id(subnet_id)?)
+                .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
+            validators = subnet.validators.clone();
+            first_line = format!(
+                "Found {} validator(s) on Subnet '{}':",
+                type_colorize(&subnet.validators.len()),
+                type_colorize(&subnet_id)
+            )
+        }
+    }
 
     if json {
-        println!("{}", serde_json::to_string(&subnet.validators).unwrap());
+        println!("{}", serde_json::to_string(&validators).unwrap());
         return Ok(());
     }
 
-    println!(
-        "Found {} validator(s) on Subnet '{}':",
-        type_colorize(&subnet.validators.len()),
-        type_colorize(&subnet_id)
-    );
-    for validator in subnet.validators.iter() {
+    println!("{}", first_line);
+    for validator in validators.iter() {
         println!(
             "{}",
             template_validator_info(validator, subnet, true, true, 2)
@@ -254,6 +280,12 @@ pub(crate) fn parse(
         ValidatorSubcommands::Info { id } => {
             info(&validator.network, &validator.subnet_id, &id, config, json)
         }
-        ValidatorSubcommands::List => list(&validator.network, &validator.subnet_id, config, json),
+        ValidatorSubcommands::List { pending } => list(
+            &validator.network,
+            &validator.subnet_id,
+            pending,
+            config,
+            json,
+        ),
     }
 }

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -416,6 +416,15 @@ pub(crate) fn template_validator_add(
 pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: u8) -> String {
     let mut info_str = String::new();
 
+    let mut subnet_vm_versions = String::new();
+    for (vm, version) in node.versions.vm_versions.subnets.iter() {
+        subnet_vm_versions.push_str(&format!(
+            "\n{}: {}",
+            type_colorize(vm),
+            type_colorize(version),
+        ));
+    }
+
     info_str.push_str(&formatdoc!(
         "
         Node '{}:{}':
@@ -424,13 +433,15 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: u8) -> 
           Public IP:     {}
           Staking port:  {}
           Versions:
-            AvalancheGo: {}
-            Database:    {}
-            Git commit:  {}
+            AvalancheGo:  {}
+            Database:     {}
+            RPC Protocol: {}
+            Git commit:   {}
             VMs:
-              AVM:        {}
-              EVM:        {}
-              PlatformVM: {}
+              AvalancheVM: {}
+              Coreth:      {}
+              PlatformVM:  {}
+              Subnet VMs:{}
           Uptime:
             Rewarding stake:  {}%
             Weighted average: {}%",
@@ -442,10 +453,15 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: u8) -> 
         type_colorize(&node.staking_port),
         type_colorize(&node.versions.avalanchego_version),
         type_colorize(&node.versions.database_version),
+        type_colorize(&node.versions.rpc_protocol_version),
         type_colorize(&node.versions.git_commit),
         type_colorize(&node.versions.vm_versions.avm),
         type_colorize(&node.versions.vm_versions.evm),
         type_colorize(&node.versions.vm_versions.platform),
+        match subnet_vm_versions.is_empty() {
+            true => String::from("  []"),
+            false => indent::indent_all_by(8, subnet_vm_versions),
+        },
         type_colorize(&node.uptime.rewarding_stake_percentage),
         type_colorize(&node.uptime.weighted_average_percentage),
     ));

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -60,25 +60,51 @@ pub(crate) fn template_blockchain_info(
         info_str.push_str(&formatdoc!(
             "
             - {}:
-               ID:      {}
-               VM type: {}
-               RPC URL: {}",
+              ID:      {}
+              VM ID:   {}
+              VM type: {}{}",
             type_colorize(&blockchain.name),
             type_colorize(&blockchain.id),
+            type_colorize(&blockchain.vm_id),
             type_colorize(&blockchain.vm_type),
-            type_colorize(&blockchain.rpc_url),
+            if !blockchain.rpc_url.is_empty() {
+                indent::indent_all_by(
+                    2,
+                    formatdoc!(
+                        "
+
+                    RPC URL: {}",
+                        type_colorize(&blockchain.rpc_url)
+                    ),
+                )
+            } else {
+                "".to_string()
+            }
         ));
     } else {
         info_str.push_str(&formatdoc!(
             "
             Blockchain '{}':
               ID:      {}
-              VM type: {}
-              RPC URL: {}",
+              VM ID:   {}
+              VM type: {}{}",
             type_colorize(&blockchain.name),
             type_colorize(&blockchain.id),
+            type_colorize(&blockchain.vm_id),
             type_colorize(&blockchain.vm_type),
-            type_colorize(&blockchain.rpc_url),
+            if !blockchain.rpc_url.is_empty() {
+                indent::indent_all_by(
+                    2,
+                    formatdoc!(
+                        "
+
+                    RPC URL: {}",
+                        type_colorize(&blockchain.rpc_url)
+                    ),
+                )
+            } else {
+                "".to_string()
+            }
         ));
     }
 
@@ -97,8 +123,8 @@ pub(crate) fn template_validator_info(
     let common_info = &formatdoc!(
         "
         Tx ID:            {}
-        Start time:       {}
-        End time:         {}
+        Start time (UTC): {}
+        End time (UTC):   {}
         ",
         type_colorize(&validator.tx_id),
         type_colorize(&human_readable_timestamp(validator.start_time)),

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-avalanche-types = { version = "0.0.386", features = [
+avalanche-types = { version = "0.0.393", features = [
 	"jsonrpc_client",
 	"wallet",
 	"subnet_evm",

--- a/crates/ash_sdk/README.md
+++ b/crates/ash_sdk/README.md
@@ -70,12 +70,12 @@ avalancheNetworks:
             rpcUrl: https://api.avax.network/ext/bc/P
           - id: 2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://api.avax.network/ext/bc/C/rpc
           - id: 2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://api.avax.network/ext/bc/X
 ```

--- a/crates/ash_sdk/conf/default.yml
+++ b/crates/ash_sdk/conf/default.yml
@@ -10,16 +10,17 @@ avalancheNetworks:
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
+            vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
             rpcUrl: https://api.avax.network/ext/bc/P
           - id: 2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://api.avax.network/ext/bc/C/rpc
           - id: 2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://api.avax.network/ext/bc/X
   - name: fuji
@@ -29,16 +30,17 @@ avalancheNetworks:
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
+            vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
             rpcUrl: https://api.avax-test.network/ext/bc/P
           - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://api.avax-test.network/ext/bc/C/rpc
           - id: 2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://api.avax-test.network/ext/bc/X
   - name: mainnet-ankr
@@ -48,16 +50,17 @@ avalancheNetworks:
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
+            vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
             rpcUrl: https://rpc.ankr.com/avalanche-p
           - id: 2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://rpc.ankr.com/avalanche-c
           - id: 2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://rpc.ankr.com/avalanche-x
   - name: fuji-ankr
@@ -67,16 +70,17 @@ avalancheNetworks:
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
+            vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
             rpcUrl: https://rpc.ankr.com/avalanche_fuji-p
           - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://rpc.ankr.com/avalanche_fuji-c
           - id: 2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://rpc.ankr.com/avalanche_fuji-x
   - name: mainnet-blast
@@ -86,16 +90,17 @@ avalancheNetworks:
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
+            vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
             rpcUrl: https://ava-mainnet.public.blastapi.io/ext/bc/P
           - id: 2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc
           - id: 2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://ava-mainnet.public.blastapi.io/ext/bc/X
   - name: fuji-blast
@@ -105,15 +110,16 @@ avalancheNetworks:
         blockchains:
           - id: 11111111111111111111111111111111LpoYY
             name: P-Chain
+            vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
             rpcUrl: https://ava-testnet.public.blastapi.io/ext/bc/P
           - id: 2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://ava-testnet.public.blastapi.io/ext/bc/C/rpc
           - id: 2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://ava-testnet.public.blastapi.io/ext/bc/X

--- a/crates/ash_sdk/src/avalanche.rs
+++ b/crates/ash_sdk/src/avalanche.rs
@@ -266,6 +266,34 @@ impl AvalancheNetwork {
         Ok(())
     }
 
+    /// Update the pending validators of a Subnet by querying an API endpoint
+    pub fn update_subnet_pending_validators(&mut self, subnet_id: Id) -> Result<(), AshError> {
+        let rpc_url = &self.get_pchain()?.rpc_url;
+
+        let validators = platformvm::get_pending_validators(rpc_url, subnet_id)?;
+
+        // Replace the pending validators of the Subnet
+        let mut subnet = self.get_subnet(subnet_id)?.clone();
+
+        subnet.pending_validators = validators;
+
+        // Get the index of the Subnet
+        let subnet_index = self
+            .subnets
+            .iter()
+            .position(|subnet| subnet.id == subnet_id)
+            .ok_or(AvalancheNetworkError::NotFound {
+                network: self.name.clone(),
+                target_type: "Subnet".to_string(),
+                target_value: subnet_id.to_string(),
+            })?;
+
+        // Replace the Subnet
+        self.subnets[subnet_index] = subnet;
+
+        Ok(())
+    }
+
     /// Check if the operation is allowed on the network
     /// If not, return an error
     fn check_operation_allowed(

--- a/crates/ash_sdk/src/avalanche/blockchains.rs
+++ b/crates/ash_sdk/src/avalanche/blockchains.rs
@@ -15,15 +15,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AvalancheBlockchain {
+    #[serde(default)]
     pub id: Id,
     pub name: String,
     #[serde(skip)]
     pub subnet_id: Id,
-    #[serde(default)]
+    #[serde(default, rename = "vmID")]
     pub vm_id: Id,
-    #[serde(default)]
     pub vm_type: AvalancheVmType,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub rpc_url: String,
 }
 

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -100,7 +100,7 @@ pub fn is_bootstrapped(rpc_url: &str, chain: &str) -> Result<bool, RpcError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use avalanche_types::{ids::node::Id as NodeId, jsonrpc::info::VmVersions};
+    use avalanche_types::ids::node::Id as NodeId;
     use std::{
         net::{IpAddr, Ipv4Addr},
         str::FromStr,

--- a/crates/ash_sdk/src/avalanche/nodes.rs
+++ b/crates/ash_sdk/src/avalanche/nodes.rs
@@ -158,8 +158,7 @@ pub struct AvalancheNodeVersions {
     pub database_version: String,
     pub git_commit: String,
     pub vm_versions: VmVersions,
-    // Not yet implemented in avalanche_types
-    // pub rpc_protocol_version: String,
+    pub rpc_protocol_version: String,
 }
 
 impl From<GetNodeVersionResult> for AvalancheNodeVersions {
@@ -169,6 +168,7 @@ impl From<GetNodeVersionResult> for AvalancheNodeVersions {
             database_version: node_version.database_version,
             git_commit: node_version.git_commit,
             vm_versions: node_version.vm_versions,
+            rpc_protocol_version: node_version.rpc_protocol_version,
         }
     }
 }
@@ -228,6 +228,7 @@ mod tests {
         assert!(!node.versions.database_version.is_empty());
         assert!(!node.versions.git_commit.is_empty());
         assert!(node.versions.vm_versions != VmVersions::default());
+        assert!(!node.versions.rpc_protocol_version.is_empty());
 
         // Test that the node uptime is not equal to 0
         assert_ne!(node.uptime.rewarding_stake_percentage, 0.0);

--- a/crates/ash_sdk/src/avalanche/subnets.rs
+++ b/crates/ash_sdk/src/avalanche/subnets.rs
@@ -41,8 +41,10 @@ pub struct AvalancheSubnet {
     /// List of the Subnet's blockchains
     pub blockchains: Vec<AvalancheBlockchain>,
     /// List of the Subnet's validators
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub validators: Vec<AvalancheSubnetValidator>,
+    #[serde(default)]
+    pub pending_validators: Vec<AvalancheSubnetValidator>,
 }
 
 impl AvalancheSubnet {
@@ -241,16 +243,26 @@ pub struct AvalancheSubnetValidator {
     // TODO: Store as DateTime::<Utc>?
     pub start_time: u64,
     pub end_time: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stake_amount: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub weight: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub potential_reward: Option<u64>,
     pub connected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uptime: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub validation_reward_owner: Option<AvalancheOutputOwners>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegator_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegator_weight: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegators: Option<Vec<AvalancheSubnetDelegator>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation_fee: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation_reward_owner: Option<AvalancheOutputOwners>,
 }
 
@@ -299,7 +311,9 @@ pub struct AvalancheSubnetDelegator {
     pub start_time: u64,
     pub end_time: u64,
     pub stake_amount: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub potential_reward: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reward_owner: Option<AvalancheOutputOwners>,
 }
 

--- a/crates/ash_sdk/src/avalanche/wallets.rs
+++ b/crates/ash_sdk/src/avalanche/wallets.rs
@@ -117,6 +117,7 @@ impl AvalancheWallet {
 
 /// Avalanche wallet information
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AvalancheWalletInfo {
     /// X-Chain address
     pub xchain_address: String,

--- a/crates/ash_sdk/tests/conf/quicknode.yml
+++ b/crates/ash_sdk/tests/conf/quicknode.yml
@@ -14,11 +14,11 @@ avalancheNetworks:
             rpcUrl: https://${ASH_QUICKNODE_FUJI_ENDPOINT}.discover.quiknode.pro/${ASH_QUICKNODE_FUJI_TOKEN}/ext/bc/P
           - id: yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp
             name: C-Chain
-            vmId: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
+            vmID: mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6
             vmType: Coreth
             rpcUrl: https://${ASH_QUICKNODE_FUJI_ENDPOINT}.discover.quiknode.pro/${ASH_QUICKNODE_FUJI_TOKEN}/ext/bc/C/rpc
           - id: 2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm
             name: X-Chain
-            vmId: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
+            vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://${ASH_QUICKNODE_FUJI_ENDPOINT}.discover.quiknode.pro/${ASH_QUICKNODE_FUJI_TOKEN}/ext/bc/X


### PR DESCRIPTION
### Linked issues

- Fixes #51 
- Fixes #53 
- Fixes #54 

### Changes

- SDK
  - Adapt to changes in https://github.com/ava-labs/avalanche-types-rs/pull/87: fetch all VMs versions + add `rpc_protocol_version` field
  - Add `pending_validators` field to `AvalancheSubnet` and add the necessary functions to update it
  - Make the `id` field optional for `AvalancheBlockchain` and thus also in the configuration files. This information will be fetched from the P-Chain anyway.
  - Update the C-Chain and X-Chain `id` and `vmID` fields on network subnets update
- CLI
  - Minor templating improvements

### Additional comments

Using a patch for `avalanche-types-rs` while waiting for https://github.com/ava-labs/avalanche-types-rs/pull/87 to be merged.
