### PR TITLE
feat: add build scripts for Linux and MacOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.x86_64-apple-darwin]
+linker = "x86_64-apple-darwin21.4-clang"
+ar = "x86_64-apple-darwin21.4-ar"
+
+[target.aarch64-apple-darwin]
+linker = "aarch64-apple-darwin21.4-clang"
+ar = "aarch64-apple-darwin21.4-ar"

--- a/README.md
+++ b/README.md
@@ -30,14 +30,27 @@ cd ash-rs
 # Run the library tests
 cargo test
 
-# Build a release
-cargo build --release
-
 # Run the CLI
 ## Debug mode
 cargo run -- --help
 ## Release mode
 cargo run --release -- --help
+```
+
+### Releasing
+
+Use the `build*.sh` scripts to build the CLI binary. The binary will be archived to `ash-${PLATFORM}-${ARCH}-v${VERSION}.tar.gz` where `PLATFORM` is `linux` or `macos`, `ARCH` is `amd64` or `arm64`, and `VERSION` is the version of the crate. A SHA512 checksum file will also be generated.
+
+For MacOS builds, [osxcross](https://github.com/tpoechtrager/osxcross) is used to cross-compile the binary. See [scripts/osxcross_setup.sh](./scripts/osxcross_setup.sh) for the setup script.
+
+```sh
+# Build a release for Linux only
+./scripts/build_linux.sh --release
+# Build a release for Mac only
+./scripts/build_macos.sh --release
+# Build a release for both Mac and Linux
+# Requires osxcross to be installed. See ./scripts/osxcross_setup.sh
+./sripts/build.sh --release
 ```
 
 ### Advanced testing

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Build Ash CLI for Linux and MacOS
+# Any argument will be passed to cargo build
+
+# Build Ash CLI for Linux
+"$(dirname "${BASH_SOURCE[0]}")/build_linux.sh" "$@"
+
+# Build Ash CLI for Mac
+"$(dirname "${BASH_SOURCE[0]}")/build_macos.sh" "$@"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Build Ash CLI for Linux
+# Any argument will be passed to cargo build
+
+# The script assumes it is run on a Debian-based Linux distro (e.g. Ubuntu)
+
+# Build Ash CLI for Linux
+echo "Building Ash CLI for Linux..."
+cargo build "$@"
+
+# Get current version
+PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+')
+
+# If any argument passed is '--release', binaries are in 'target/release'
+# Otherwise, binaries are in 'target/debug'
+if [[ "$*" == *"--release"* ]]; then
+  LINUX_TARGET_DIR="target/release"
+else
+  LINUX_TARGET_DIR="target/debug"
+fi
+
+# Create an archive with the Ash CLI binary
+## Linux
+cd "$LINUX_TARGET_DIR" || exit 1
+rm -f "ash-linux-amd64-v$PACKAGE_VERSION.tar.gz"
+tar -czf "ash-linux-amd64-v$PACKAGE_VERSION.tar.gz" ash
+sha512sum "ash-linux-amd64-v$PACKAGE_VERSION.tar.gz" >"ash-linux-amd64-v$PACKAGE_VERSION.tar.gz.sha512"
+cd "$OLDPWD" || exit 1

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Build Ash CLI for MacOS
+# Any argument will be passed to cargo build
+# Inspired from https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html
+
+# The script assumes it is run on a Debian-based Linux distro (e.g. Ubuntu)
+# and that the following packages are installed: clang, gcc, g++, zlib1g-dev, libmpc-dev, libmpfr-dev, libgmp-dev
+# osxcross (see ./scripts/osxcross_setup.sh)
+
+# Environment variables
+# OSXCROSS_PATH: path to osxcross installation
+
+# Check that the dependencies are installed
+# Dependencies: clang, gcc, g++, zlib1g-dev, libmpc-dev, libmpfr-dev, libgmp-dev
+for pkg in clang gcc g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev; do
+  if ! dpkg -s $pkg >/dev/null 2>&1; then
+    echo "Error: $pkg is not installed. Please install it and try again."
+    exit 1
+  fi
+done
+
+# Add *-apple-darwin targets to rustup
+rustup target add x86_64-apple-darwin
+rustup target add aarch64-apple-darwin
+
+# Check that OSXCROSS_PATH is set
+if [ -z "$OSXCROSS_PATH" ]; then
+  echo "Error: OSXCROSS_PATH is not set. Please set it and try again."
+  exit 1
+fi
+
+# Build Ash CLI for Mac x86_64
+echo "Building Ash CLI for MacOS x86_64..."
+PATH="$OSXCROSS_PATH/target/bin:$PATH" \
+  CC=o64-clang \
+  CXX=o64-clang++ \
+  LIBZ_SYS_STATIC=1 \
+  cargo build --target x86_64-apple-darwin "$@"
+
+# Build Ash CLI for Mac aarch64
+echo "Building Ash CLI for MacOS aarch64..."
+PATH="$OSXCROSS_PATH/target/bin:$PATH" \
+  CC=o64-clang \
+  CXX=o64-clang++ \
+  TARGET_CC="$OSXCROSS_PATH/target/bin/aarch64-apple-darwin21.4-clang" \
+  TARGET_AR="$OSXCROSS_PATH/target/bin/aarch64-apple-darwin21.4-ar" \
+  LIBZ_SYS_STATIC=1 \
+  cargo build --target aarch64-apple-darwin "$@"
+
+# Get current version
+PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+')
+
+# If any argument passed is '--release', binaries are in 'target/release'
+# Otherwise, binaries are in 'target/debug'
+if [[ "$*" == *"--release"* ]]; then
+  MAC_AMD_TARGET_DIR="target/x86_64-apple-darwin/release"
+  MAC_ARM_TARGET_DIR="target/aarch64-apple-darwin/release"
+else
+  MAC_AMD_TARGET_DIR="target/x86_64-apple-darwin/debug"
+  MAC_ARM_TARGET_DIR="target/aarch64-apple-darwin/debug"
+fi
+
+# Create an archive with the Ash CLI binary
+## Mac x86_64
+cd "$MAC_AMD_TARGET_DIR" || exit 1
+rm -f "ash-macos-amd64-v$PACKAGE_VERSION.tar.gz"
+tar -czf "ash-macos-amd64-v$PACKAGE_VERSION.tar.gz" ash
+sha512sum "ash-macos-amd64-v$PACKAGE_VERSION.tar.gz" >"ash-macos-amd64-v$PACKAGE_VERSION.tar.gz.sha512"
+cd "$OLDPWD" || exit 1
+
+## Mac aarch64
+cd "$MAC_ARM_TARGET_DIR" || exit 1
+rm -f "ash-macos-arm64-v$PACKAGE_VERSION.tar.gz"
+tar -czf "ash-macos-arm64-v$PACKAGE_VERSION.tar.gz" ash
+sha512sum "ash-macos-arm64-v$PACKAGE_VERSION.tar.gz" >"ash-macos-arm64-v$PACKAGE_VERSION.tar.gz.sha512"
+cd "$OLDPWD" || exit 1

--- a/scripts/osxcross_setup.sh
+++ b/scripts/osxcross_setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install osxcross (run the script where you want to install osxcross)
+
+# Environment variables
+## Using the same version as Avalanche CLI by default
+## See https://github.com/ava-labs/avalanche-cli/blob/5b8e17abceabaffeca38a3c8fcc43fbc2ab9eb7c/.github/workflows/release.yml#L76
+MACOSX_SDK_VERSION=${MACOSX_SDK_VERSION:-12.3}
+MACOSX_SDK_CHECKSUM="${MACOSX_SDK_CHECKSUM:-3abd261ceb483c44295a6623fdffe5d44fc4ac2c872526576ec5ab5ad0f6e26c}"
+
+git clone https://github.com/tpoechtrager/osxcross
+cd osxcross || exit 1
+wget -nc "https://github.com/joseluisq/macosx-sdks/releases/download/${MACOSX_SDK_VERSION}/MacOSX${MACOSX_SDK_VERSION}.sdk.tar.xz"
+echo "${MACOSX_SDK_CHECKSUM}  MacOSX${MACOSX_SDK_VERSION}.sdk.tar.xz" | sha256sum -c -
+mv "MacOSX${MACOSX_SDK_VERSION}.sdk.tar.xz" tarballs/
+UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh


### PR DESCRIPTION
### Changes

- Add Bash scripts to build releases, and archive + hash them. We support building for Linux (current dev OS) and MacOS (thanks to [osxcross](https://github.com/tpoechtrager/osxcross)).

### Additional comments

Use `osxcross_setup.sh` to install osxcross locally. We need to build for MacOS AMD64 (before M1) and ARM64 (after M1).

Rust targets mapping:
- `x86_64-apple-darwin` -> AMD64
- `aarch64-apple-darwin` -> ARM64
