### PR TITLE
feat(cli): add tx_cmd info to version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "ash_cli"
-version = "0.2.2"
+version = "0.2.3-alpha.1"
 dependencies = [
  "ash_sdk",
  "async-std",
@@ -165,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "ash_sdk"
-version = "0.2.2"
+version = "0.2.3-alpha.1"
 dependencies = [
  "async-std",
  "avalanche-types",
@@ -293,7 +302,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -347,7 +356,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -410,8 +419,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avalanche-types"
-version = "0.0.393"
-source = "git+https://github.com/AshAvalanche/avalanche-types-rs?branch=70-vm-versions-hashmap#f0409a69857c372b8647d63e44f00d138a637bbe"
+version = "0.0.400"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b52dfbe155ffa94f21bdeb376e081e99d47e1d915cc860a365151f12cb88a85"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",
@@ -422,10 +432,11 @@ dependencies = [
  "chrono",
  "cmp-manager",
  "ecdsa 0.16.7",
- "ethers-core 2.0.4",
- "ethers-providers 2.0.4",
+ "ethers-core 2.0.7",
+ "ethers-providers 2.0.7",
  "hex",
  "hmac",
+ "hyper",
  "k256 0.13.1",
  "lazy_static",
  "log",
@@ -445,11 +456,27 @@ dependencies = [
  "sha2 0.10.6",
  "sha3",
  "spki 0.7.2",
+ "strum",
  "thiserror",
  "tokio",
  "url",
  "zerocopy",
  "zeroize",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -895,7 +922,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1180,7 +1207,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1191,7 +1218,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1315,7 +1342,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1659,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.4"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198ea9efa8480fa69f73d31d41b1601dace13d053c6fe4be6f5878d9dfcf0108"
+checksum = "6da5fa198af0d3be20c19192df2bd9590b92ce09a8421e793bec8851270f1b05"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1669,7 +1696,6 @@ dependencies = [
  "elliptic-curve 0.13.5",
  "ethabi",
  "generic-array 0.14.7",
- "getrandom",
  "hex",
  "k256 0.13.1",
  "num_enum",
@@ -1766,21 +1792,20 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.4"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1009041f40476b972b5d79346cc512e97c662b1a0a2f78285eabe9a122909783"
+checksum = "56b498fd2a6c019d023e43e83488cd1fb0721f299055975aa6bac8dbf1e95f2c"
 dependencies = [
  "async-trait",
  "auto_impl 1.1.0",
  "base64 0.21.2",
  "bytes",
  "enr",
- "ethers-core 2.0.4",
+ "ethers-core 2.0.7",
  "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",
- "getrandom",
  "hashers",
  "hex",
  "http",
@@ -1792,7 +1817,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.18.0",
+ "tokio-tungstenite 0.19.0",
  "tracing",
  "tracing-futures",
  "url",
@@ -2064,7 +2089,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2148,6 +2173,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -2340,7 +2371,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2660,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libm"
@@ -2884,7 +2915,16 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2956,7 +2996,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3156,7 +3196,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3251,14 +3291,14 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -3348,6 +3388,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,9 +3462,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3442,7 +3492,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
@@ -3475,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "protoc-gen-prost"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81e3a9bb429fec47008b209896f0b9ab99fbcbc1c3733b385d43fbfd64dd2ca"
+checksum = "10dfa031ad41fdcfb180de73ece3ed076250f1132a13ad6bba218699f612fb95"
 dependencies = [
  "once_cell",
  "prost",
@@ -3488,18 +3538,18 @@ dependencies = [
 
 [[package]]
 name = "protoc-gen-tonic"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725a07a704f9cf7a956b302c21d81b5516ed5ee6cfbbf827edb69beeaae6cc30"
+checksum = "1f51f5331d7f5bbb5724ae6a397e14bd2e71d65d03f0b2cfb4fea308158b2b56"
 dependencies = [
  "heck",
- "prettyplease",
+ "prettyplease 0.2.12",
  "prost",
  "prost-build",
  "prost-types",
  "protoc-gen-prost",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.29",
  "tonic-build",
 ]
 
@@ -3722,7 +3772,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -3856,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.6.1"
+version = "6.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b68543d5527e158213414a92832d2aab11a84d2571a5eb021ebe22c43aab066"
+checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3867,22 +3917,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "6.5.0"
+version = "6.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4e0f0ced47ded9a68374ac145edd65a6c1fa13a96447b873660b2a568a0fd7"
+checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 1.0.109",
+ "syn 2.0.29",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.5.0"
+version = "7.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
+checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
 dependencies = [
  "sha2 0.10.6",
  "walkdir",
@@ -3915,6 +3965,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hex"
@@ -4180,9 +4236,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -4200,13 +4256,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4257,7 +4313,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4295,7 +4351,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4417,6 +4473,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4544,9 +4610,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4612,7 +4678,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4688,11 +4754,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -4700,7 +4766,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4713,7 +4779,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4760,23 +4826,22 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tungstenite 0.17.3",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "tokio",
- "tokio-rustls 0.23.4",
- "tungstenite 0.18.0",
- "webpki",
- "webpki-roots",
+ "tokio-rustls 0.24.0",
+ "tungstenite 0.19.0",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -4821,11 +4886,11 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build",
  "quote",
@@ -4858,7 +4923,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4909,18 +4974,18 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
  "rand",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "sha1",
  "thiserror",
  "url",
@@ -5013,7 +5078,7 @@ dependencies = [
  "serde_json",
  "url",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -5132,7 +5197,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -5166,7 +5231,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5219,6 +5284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -5563,7 +5637,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 members = ["crates/ash_cli", "crates/ash_sdk"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3-alpha.1"
 edition = "2021"
 authors = ["E36 Knots"]
 homepage = "https://ash.center"
@@ -18,6 +18,3 @@ categories = [
 	"data-structures",
 ]
 keywords = ["blockchain", "avalanche", "subnets", "ash"]
-
-[patch.crates-io]
-avalanche-types = { git = "https://github.com/AshAvalanche/avalanche-types-rs", branch = "70-vm-versions-hashmap" }

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-ash_sdk = { path = "../ash_sdk", version = "0.2.2" }
+ash_sdk = { path = "../ash_sdk", version = "0.2.3-alpha.1" }
 clap = { version = "4.0.32", features = ["derive", "env", "cargo", "string"] }
 colored = "2.0.0"
 exitcode = "1.1.2"

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -16,7 +16,7 @@ keywords.workspace = true
 
 [dependencies]
 ash_sdk = { path = "../ash_sdk", version = "0.2.2" }
-clap = { version = "4.0.32", features = ["derive", "env"] }
+clap = { version = "4.0.32", features = ["derive", "env", "cargo", "string"] }
 colored = "2.0.0"
 exitcode = "1.1.2"
 indent = "0.1.1"

--- a/crates/ash_cli/src/avalanche.rs
+++ b/crates/ash_cli/src/avalanche.rs
@@ -17,7 +17,8 @@ use ash_sdk::avalanche::AvalancheNetwork;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(about = "Interact with Avalanche Subnets, blockchains and nodes")]
+/// Interact with Avalanche Subnets, blockchains and nodes
+#[command(visible_alias = "avax")]
 pub(crate) struct AvalancheCommand {
     #[command(subcommand)]
     command: AvalancheSubcommands,

--- a/crates/ash_cli/src/avalanche/blockchain.rs
+++ b/crates/ash_cli/src/avalanche/blockchain.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     avalanche::{wallet::*, *},
-    utils::{error::CliError, parsing::*, templating::*},
+    utils::{error::CliError, parsing::*, templating::*, version_tx_cmd},
 };
 use ash_sdk::avalanche::{
     blockchains::AvalancheBlockchain,
@@ -34,7 +34,7 @@ pub(crate) struct BlockchainCommand {
 #[derive(Subcommand)]
 enum BlockchainSubcommands {
     /// Create a new blockchain
-    #[command()]
+    #[command(version = version_tx_cmd(true))]
     Create {
         /// Blockchain name
         name: String,

--- a/crates/ash_cli/src/avalanche/network.rs
+++ b/crates/ash_cli/src/avalanche/network.rs
@@ -3,7 +3,7 @@
 
 // Module that contains the network subcommand parser
 
-use crate::utils::{error::CliError, templating::*};
+use crate::utils::{error::CliError, templating::*, version_tx_cmd};
 use ash_sdk::conf::AshConfig;
 use clap::{Parser, Subcommand};
 
@@ -18,7 +18,7 @@ pub(crate) struct NetworkCommand {
 #[derive(Subcommand)]
 enum NetworkSubcommands {
     /// List known Avalanche networks
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     List,
 }
 

--- a/crates/ash_cli/src/avalanche/node.rs
+++ b/crates/ash_cli/src/avalanche/node.rs
@@ -3,7 +3,7 @@
 
 // Module that contains the node subcommand parser
 
-use crate::utils::{error::CliError, templating::*};
+use crate::utils::{error::CliError, templating::*, version_tx_cmd};
 use ash_sdk::avalanche::nodes::AvalancheNode;
 use clap::{Parser, Subcommand};
 
@@ -27,10 +27,10 @@ pub(crate) struct NodeCommand {
 #[derive(Subcommand)]
 enum NodeSubcommands {
     /// Show node information
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     Info,
     /// Check if a chain is done bootstrapping on the node
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     IsBootstrapped {
         /// Chain ID or alias
         chain: String,

--- a/crates/ash_cli/src/avalanche/subnet.rs
+++ b/crates/ash_cli/src/avalanche/subnet.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     avalanche::{wallet::*, *},
-    utils::{error::CliError, parsing::*, templating::*},
+    utils::{error::CliError, parsing::*, templating::*, version_tx_cmd},
 };
 use ash_sdk::avalanche::subnets::AvalancheSubnet;
 use async_std::task;
@@ -31,10 +31,10 @@ pub(crate) struct SubnetCommand {
 #[derive(Subcommand)]
 enum SubnetSubcommands {
     /// List the network's Subnets
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     List,
     /// Show Subnet information
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     Info {
         /// Subnet ID
         id: String,
@@ -43,7 +43,7 @@ enum SubnetSubcommands {
         extended: bool,
     },
     /// Create a new Subnet
-    #[command()]
+    #[command(version = version_tx_cmd(true))]
     Create {
         /// Private key to sign the transaction with
         #[arg(long, short = 'p', env = "AVALANCHE_PRIVATE_KEY")]

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     avalanche::{wallet::*, *},
-    utils::{error::CliError, parsing::*, templating::*},
+    utils::{error::CliError, parsing::*, templating::*, version_tx_cmd},
 };
 use ash_sdk::avalanche::{subnets::AvalancheSubnetType, AVAX_PRIMARY_NETWORK_ID};
 use async_std::task;
@@ -39,7 +39,7 @@ pub(crate) struct ValidatorCommand {
 #[derive(Subcommand)]
 enum ValidatorSubcommands {
     /// Add a validator to a Subnet
-    #[command()]
+    #[command(version = version_tx_cmd(true))]
     Add {
         /// Validator NodeID
         id: String,
@@ -70,14 +70,14 @@ enum ValidatorSubcommands {
         wait: bool,
     },
     /// List the Subnet's validators
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     List {
         /// List pending validators
         #[arg(long, short = 'p')]
         pending: bool,
     },
     /// Show validator information
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     Info {
         /// Validator NodeID
         id: String,
@@ -179,7 +179,7 @@ fn add(
     start_time: String,
     end_time: String,
     delegation_fee: u32,
-    private_key: String,
+    private_key: &str,
     key_encoding: PrivateKeyEncoding,
     wait: bool,
     config: Option<&str>,
@@ -270,7 +270,7 @@ pub(crate) fn parse(
             start_time,
             end_time,
             delegation_fee,
-            private_key,
+            &private_key,
             key_encoding,
             wait,
             config,

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -195,7 +195,7 @@ fn add(
     let subnet = network
         .get_subnet(parse_id(subnet_id)?)
         .map_err(|e| CliError::dataerr(format!("Error loading Subnet info: {e}")))?;
-    let wallet = create_wallet(&network, &private_key, key_encoding)?;
+    let wallet = create_wallet(&network, private_key, key_encoding)?;
 
     if wait {
         eprintln!("Waiting for transaction to be accepted...");

--- a/crates/ash_cli/src/avalanche/vm.rs
+++ b/crates/ash_cli/src/avalanche/vm.rs
@@ -3,7 +3,7 @@
 
 // Module that contains the vm subcommand parser
 
-use crate::utils::{error::CliError, templating::*};
+use crate::utils::{error::CliError, templating::*, version_tx_cmd};
 use ash_sdk::avalanche::vms::{encode_genesis_data, generate_vm_id, AvalancheVmType};
 use clap::{Parser, Subcommand};
 
@@ -18,7 +18,7 @@ pub(crate) struct VmCommand {
 #[derive(Subcommand)]
 enum VmSubcommands {
     /// Encode a VM genesis (in JSON) to bytes
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     EncodeGenesis {
         /// Path to the genesis JSON file
         genesis_file: String,
@@ -27,7 +27,7 @@ enum VmSubcommands {
         vm_type: AvalancheVmType,
     },
     /// Generate the VM ID from the VM name
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     GenerateId {
         /// VM name
         vm_name: String,

--- a/crates/ash_cli/src/avalanche/wallet.rs
+++ b/crates/ash_cli/src/avalanche/wallet.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     avalanche::*,
-    utils::{error::CliError, templating::*},
+    utils::{error::CliError, templating::*, version_tx_cmd},
 };
 use ash_sdk::avalanche::wallets::{generate_private_key, AvalancheWallet, AvalancheWalletInfo};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -31,7 +31,7 @@ pub(crate) struct WalletCommand {
 #[derive(Subcommand)]
 enum WalletSubcommands {
     /// Get information about a wallet (linked to a private key)
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     Info {
         /// Private key of the wallet
         #[arg(env = "AVALANCHE_PRIVATE_KEY")]
@@ -41,7 +41,7 @@ enum WalletSubcommands {
         key_encoding: PrivateKeyEncoding,
     },
     /// Randomly generate a private key (giving access to a wallet)
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     Generate,
 }
 

--- a/crates/ash_cli/src/avalanche/x.rs
+++ b/crates/ash_cli/src/avalanche/x.rs
@@ -6,7 +6,7 @@
 use crate::{
     avalanche::{wallet::*, *},
     utils::templating::template_xchain_balance,
-    utils::{error::CliError, templating::*},
+    utils::{error::CliError, templating::*, version_tx_cmd},
 };
 use async_std::task;
 use clap::{Parser, Subcommand};
@@ -32,7 +32,7 @@ pub(crate) struct XCommand {
 #[derive(Subcommand)]
 enum XSubcommands {
     /// Get the balance of an address for a given asset
-    #[command()]
+    #[command(version = version_tx_cmd(false))]
     Balance {
         /// Address to get the balance of
         address: String,
@@ -41,7 +41,7 @@ enum XSubcommands {
         asset_id: String,
     },
     /// Transfer any amount of a given asset to an address
-    #[command()]
+    #[command(version = version_tx_cmd(true))]
     Transfer {
         /// Amount of asset to send (in AVAX equivalent, 1 AVAX = 10^9 nAVAX)
         amount: f64,

--- a/crates/ash_cli/src/conf.rs
+++ b/crates/ash_cli/src/conf.rs
@@ -3,12 +3,13 @@
 
 // Module that contains the conf subcommand parser
 
-use crate::utils::error::CliError;
+use crate::utils::{error::CliError, version_tx_cmd};
 use ash_sdk::conf::AshConfig;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(about = "Interact with Ash configuration files")]
+/// Interact with Ash configuration files
+#[command()]
 pub(crate) struct ConfCommand {
     #[command(subcommand)]
     command: ConfSubcommands,
@@ -16,11 +17,13 @@ pub(crate) struct ConfCommand {
 
 #[derive(Subcommand)]
 enum ConfSubcommands {
-    #[command(about = "Initialize an Ash config file")]
+    /// Initialize an Ash config file
+    #[command(version = version_tx_cmd(false))]
     Init {
         #[arg(from_global)]
         config: String,
-        #[arg(long, help = "Overwrite existing config file")]
+        /// Overwrite existing config file
+        #[arg(long)]
         force: bool,
     },
 }

--- a/crates/ash_cli/src/main.rs
+++ b/crates/ash_cli/src/main.rs
@@ -15,8 +15,8 @@ use colored::Colorize;
 use std::process::exit;
 
 #[derive(Parser)]
+/// Ash CLI. More information at https://ash.center/docs/toolkit/ash-cli/introduction
 #[command(author, version)]
-#[command(about = "Ash CLI")]
 struct Cli {
     #[command(subcommand)]
     command: CliCommands,
@@ -30,7 +30,6 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum CliCommands {
-    #[command(visible_alias = "avax")]
     Avalanche(avalanche::AvalancheCommand),
     Conf(conf::ConfCommand),
 }

--- a/crates/ash_cli/src/utils.rs
+++ b/crates/ash_cli/src/utils.rs
@@ -4,3 +4,11 @@
 pub(crate) mod error;
 pub(crate) mod parsing;
 pub(crate) mod templating;
+
+use clap::{builder::Str, crate_version};
+
+/// Enrich the version information with whether the command triggers a transaction or not
+/// This is used to help use the CLI in a non-interactive way
+pub(crate) fn version_tx_cmd(is_tx: bool) -> Str {
+    Str::from(format!("{} (tx_cmd={})", crate_version!(), is_tx))
+}

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-avalanche-types = { version = "0.0.393", features = [
+avalanche-types = { version = "0.0.400", features = [
 	"jsonrpc_client",
 	"wallet",
 	"subnet_evm",

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -10,7 +10,7 @@ echo "Building Ash CLI for Linux..."
 cargo build "$@"
 
 # Get current version
-PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+')
+PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+-?(alpha|beta)?(.\d+)?')
 
 # If any argument passed is '--release', binaries are in 'target/release'
 # Otherwise, binaries are in 'target/debug'

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -49,7 +49,7 @@ PATH="$OSXCROSS_PATH/target/bin:$PATH" \
   cargo build --target aarch64-apple-darwin "$@"
 
 # Get current version
-PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+')
+PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+-?(alpha|beta)?(.\d+)?')
 
 # If any argument passed is '--release', binaries are in 'target/release'
 # Otherwise, binaries are in 'target/debug'


### PR DESCRIPTION
### Changes

- Use the `--version` output to provide information on whether a command triggers a transaction. This takes the form of `tx_cmd=(true|false)`. Example with the `avalanche subnet create` command:
  ```bash
  $ ash avalanche subnet create --version
  ash_cli-avalanche-subnet-create 0.2.3-alpha.1 (tx_cmd=true)
  ```
- Support `alpha|beta` versions in build scripts

### Additional comments

I did not find any easier way to add metadata around a command, the goal being to ease maintenance on dependant tools like the Ansible Avalanche Collection. IMO this is pretty acceptable for now as we don't make any usage of `--version` at the command level.
