### PR TITLE
ci: add build for Linux ARM64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+[target.aarch64-unknown-linux-gnu]
+ar = "aarch64-linux-gnu-ar"
+linker = "aarch64-linux-gnu-gcc"
+
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin21.4-clang"
 ar = "x86_64-apple-darwin21.4-ar"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "enum-display-derive",
  "ethers",
  "hex",
+ "openssl",
  "regex",
  "reqwest",
  "serde",
@@ -3006,6 +3007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.27.0+1.1.1v"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3023,7 @@ checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -41,3 +41,6 @@ chrono = { version = "0.4.24", features = ["clock"] }
 [dev-dependencies]
 serial_test = "2.0.0"
 tempfile = "3.3.0"
+
+[target.aarch64-unknown-linux-gnu.dependencies]
+openssl = { version = "0.10.54", features = ["vendored"] }

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -3,11 +3,19 @@
 # Build Ash CLI for Linux
 # Any argument will be passed to cargo build
 
-# The script assumes it is run on a Debian-based Linux distro (e.g. Ubuntu)
+# The script assumes it is run on a Debian-based Linux distro (e.g. Ubuntu) on an x86_64 (amd64) machine
+# and that the following packages are installed: gcc-aarch64-linux-gnu
 
-# Build Ash CLI for Linux
-echo "Building Ash CLI for Linux..."
+# Add aaarch64-unknown-linux-gnu target to rustup
+rustup target add aarch64-unknown-linux-gnu
+
+# Build Ash CLI for Linux x86_64
+echo "Building Ash CLI for Linux x86_64..."
 cargo build "$@"
+
+# Build Ash CLI for Linux aarch64
+echo "Building Ash CLI for Linux aarch64..."
+cargo build --target aarch64-unknown-linux-gnu "$@"
 
 # Get current version
 PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+-?(alpha|beta)?(.\d+)?')
@@ -15,15 +23,23 @@ PACKAGE_VERSION=$(grep '^version =' Cargo.toml | grep -oP '\d+\.\d+\.\d+-?(alpha
 # If any argument passed is '--release', binaries are in 'target/release'
 # Otherwise, binaries are in 'target/debug'
 if [[ "$*" == *"--release"* ]]; then
-  LINUX_TARGET_DIR="target/release"
+  LINUX_AMD_TARGET_DIR="target/release"
+  LINUX_ARM_TARGET_DIR="target/aarch64-unknown-linux-gnu/release"
 else
-  LINUX_TARGET_DIR="target/debug"
+  LINUX_AMD_TARGET_DIR="target/debug"
+  LINUX_ARM_TARGET_DIR="target/aarch64-unknown-linux-gnu/debug"
 fi
 
 # Create an archive with the Ash CLI binary
-## Linux
-cd "$LINUX_TARGET_DIR" || exit 1
+## Linux x86_64
+cd "$LINUX_AMD_TARGET_DIR" || exit 1
 rm -f "ash-linux-amd64-v$PACKAGE_VERSION.tar.gz"
 tar -czf "ash-linux-amd64-v$PACKAGE_VERSION.tar.gz" ash
 sha512sum "ash-linux-amd64-v$PACKAGE_VERSION.tar.gz" >"ash-linux-amd64-v$PACKAGE_VERSION.tar.gz.sha512"
 cd "$OLDPWD" || exit 1
+
+## Linux aarch64
+cd "$LINUX_ARM_TARGET_DIR" || exit 1
+rm -f "ash-linux-arm64-v$PACKAGE_VERSION.tar.gz"
+tar -czf "ash-linux-arm64-v$PACKAGE_VERSION.tar.gz" ash
+sha512sum "ash-linux-arm64-v$PACKAGE_VERSION.tar.gz" >"ash-linux-arm64-v$PACKAGE_VERSION.tar.gz.sha512"

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -74,4 +74,3 @@ cd "$MAC_ARM_TARGET_DIR" || exit 1
 rm -f "ash-macos-arm64-v$PACKAGE_VERSION.tar.gz"
 tar -czf "ash-macos-arm64-v$PACKAGE_VERSION.tar.gz" ash
 sha512sum "ash-macos-arm64-v$PACKAGE_VERSION.tar.gz" >"ash-macos-arm64-v$PACKAGE_VERSION.tar.gz.sha512"
-cd "$OLDPWD" || exit 1


### PR DESCRIPTION
### Changes

- Add build for `linux-arm64` machines

### Additional comments

We have to build for ARM64 Linux targets because Multipass VMs on Mac M1 share this architecture with the host. See https://github.com/AshAvalanche/ansible-avalanche-collection/issues/96
