### PR TITLE
Ash Console authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,12 +29,24 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -161,8 +173,12 @@ dependencies = [
  "hex",
  "indent",
  "indoc",
+ "jsonwebtoken",
+ "keyring",
  "rust_decimal",
+ "serde",
  "serde_json",
+ "whoami",
 ]
 
 [[package]]
@@ -176,6 +192,7 @@ dependencies = [
  "enum-display-derive",
  "ethers",
  "hex",
+ "oauth2",
  "openssl",
  "regex",
  "reqwest",
@@ -191,6 +208,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "ureq",
+ "url",
 ]
 
 [[package]]
@@ -243,13 +261,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -265,6 +293,18 @@ dependencies = [
  "fastrand 1.9.0",
  "futures-lite",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -309,7 +349,54 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf012553ce51eb7aa6dc2143804cc8252bd1cb681a1c5cb7fa94ca88682dee1d"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.0.0",
+ "futures-lite",
+ "rustix 0.38.13",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99f3cb3f9ff89f7d718fbb942c9eb91bedff12e396adf09a622dfe7ffec2bc2"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-core",
+ "futures-io",
+ "libc",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys",
 ]
 
 [[package]]
@@ -528,6 +615,22 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -768,6 +871,15 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
@@ -995,7 +1107,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -1042,7 +1154,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1131,6 +1243,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1293,6 +1416,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,7 +1469,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
- "aes",
+ "aes 0.8.3",
  "ctr",
  "digest",
  "hex",
@@ -1642,6 +1786,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,8 +2062,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2017,6 +2174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -2330,6 +2496,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.4",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2530,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keyring"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9549a129bd08149e0a71b2d1ce2729780d47127991bfd0a78cc1df697ec72492"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "linux-keyutils",
+ "secret-service",
+ "security-framework",
+ "winapi",
 ]
 
 [[package]]
@@ -2417,6 +2611,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-keyutils"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f27bb67f6dd1d0bb5ab582868e4f65052e58da6401188a08f0da09cf512b84b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2665,15 @@ name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -2528,6 +2741,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2760,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2566,6 +2805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2830,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2628,6 +2888,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom",
+ "http",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2930,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open-fastrlp"
@@ -2738,6 +3024,16 @@ checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3683,7 +3979,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3777,6 +4073,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da1a5ad4d28c03536f82f77d9f36603f5e37d8869ac98f0a750d5b5686d8d95"
+dependencies = [
+ "aes 0.7.5",
+ "block-modes",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,6 +4175,27 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4006,6 +4342,18 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -4506,6 +4854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "uds_windows"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+dependencies = [
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,6 +4942,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4763,6 +5122,16 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"
@@ -4954,6 +5323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4975,6 +5354,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zbus"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener 2.5.3",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -5024,7 +5469,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
+ "aes 0.8.3",
  "byteorder",
  "bzip2",
  "constant_time_eq",
@@ -5066,4 +5511,42 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -27,6 +27,10 @@ enum-display-derive = "0.1.1"
 rust_decimal = "1.29.1"
 hex = "0.4.3"
 chrono = "0.4.24"
+keyring = "2.0.5"
+whoami = "1.4.1"
+jsonwebtoken = "8.3.0"
+serde = "1.0.188"
 
 [[bin]]
 name = "ash"

--- a/crates/ash_cli/src/avalanche.rs
+++ b/crates/ash_cli/src/avalanche.rs
@@ -40,9 +40,8 @@ enum AvalancheSubcommands {
 
 // Load the network configuation
 fn load_network(network_name: &str, config: Option<&str>) -> Result<AvalancheNetwork, CliError> {
-    let network = AvalancheNetwork::load(network_name, config)
-        .map_err(|e| CliError::dataerr(format!("Error loading network: {e}")))?;
-    Ok(network)
+    AvalancheNetwork::load(network_name, config)
+        .map_err(|e| CliError::dataerr(format!("Error loading network: {e}")))
 }
 
 // Recursively update the Subnets (and their blockchains)

--- a/crates/ash_cli/src/console.rs
+++ b/crates/ash_cli/src/console.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+mod auth;
+
+// Module that contains the console subcommand parser
+
+use crate::utils::error::CliError;
+use ash_sdk::console::AshConsole;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+/// Interact with the Ash Console
+pub(crate) struct ConsoleCommand {
+    #[command(subcommand)]
+    command: ConsoleSubcommands,
+}
+
+#[derive(Subcommand)]
+enum ConsoleSubcommands {
+    Auth(auth::AuthCommand),
+}
+
+const KEYRING_TARGET: &str = "ash-console";
+const KEYRING_ACCESS_TOKEN_SERVICE: &str = "access_token";
+const KEYRING_REFRESH_TOKEN_SERVICE: &str = "refresh_token";
+
+// Load the console configuation
+fn load_console(config: Option<&str>) -> Result<AshConsole, CliError> {
+    AshConsole::load(config).map_err(|e| CliError::dataerr(format!("Error loading console: {e}")))
+}
+
+// Parse console subcommand
+pub(crate) fn parse(
+    console: ConsoleCommand,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    match console.command {
+        ConsoleSubcommands::Auth(auth) => auth::parse(auth, config, json),
+    }
+}

--- a/crates/ash_cli/src/console/auth.rs
+++ b/crates/ash_cli/src/console/auth.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+// Module that contains the auth subcommand parser
+
+use crate::{
+    console::{
+        load_console, KEYRING_ACCESS_TOKEN_SERVICE, KEYRING_REFRESH_TOKEN_SERVICE, KEYRING_TARGET,
+    },
+    utils::{
+        error::CliError, get_keyring_value, store_keyring_value, templating::*, version_tx_cmd,
+    },
+};
+use ash_sdk::console::AshConsole;
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+use jsonwebtoken::{decode, DecodingKey, TokenData, Validation};
+use serde::{Deserialize, Serialize};
+
+#[derive(Parser)]
+/// Authenticate with the Ash Console
+pub(crate) struct AuthCommand {
+    #[command(subcommand)]
+    command: AuthSubcommands,
+}
+
+#[derive(Subcommand)]
+enum AuthSubcommands {
+    /// Login to the Ash Console. Credentials are stored in the device keyring.
+    #[command(version = version_tx_cmd(false))]
+    Login,
+    /// Refresh the Ash Console access token
+    #[command(version = version_tx_cmd(false))]
+    RefreshToken,
+    /// Show the current access token
+    #[command(version = version_tx_cmd(false))]
+    ShowToken,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Claims {
+    exp: usize,
+    iat: usize,
+    auth_time: usize,
+    jti: String,
+    iss: String,
+    sub: String,
+    typ: String,
+    azp: String,
+    session_state: String,
+    sid: String,
+    #[serde(rename = "preferred_username")]
+    username: String,
+    name: String,
+    given_name: String,
+    family_name: String,
+    email: String,
+}
+
+// Refresh the user access token to the Ash Console
+pub(crate) fn refresh_keyring_access_token(console: &AshConsole) -> Result<(), CliError> {
+    // Get the refresh token from the keyring
+    let refresh_token = get_keyring_value(KEYRING_TARGET, KEYRING_REFRESH_TOKEN_SERVICE)?;
+
+    // Exchange the refresh token for a new access token
+    let access_token = console
+        .oauth2
+        .refresh_access_token(&refresh_token)
+        .map_err(|e| CliError::dataerr(format!("Error refreshing access token: {e}")))?;
+
+    // Store the access token in the keyring
+    store_keyring_value(
+        KEYRING_TARGET,
+        KEYRING_ACCESS_TOKEN_SERVICE,
+        &access_token.secret().to_string(),
+    )?;
+
+    Ok(())
+}
+
+// Get the current access token from the keyring
+pub(crate) fn get_keyring_access_token() -> Result<String, CliError> {
+    get_keyring_value(KEYRING_TARGET, KEYRING_ACCESS_TOKEN_SERVICE)
+}
+
+// Decode the access token to get its token data
+pub(crate) fn decode_access_token(access_token: &str) -> Result<TokenData<Claims>, CliError> {
+    let mut token_validation = Validation::default();
+    token_validation.insecure_disable_signature_validation();
+    token_validation.validate_exp = false;
+
+    let token_data = decode::<Claims>(
+        access_token,
+        &DecodingKey::from_secret("secret".as_ref()),
+        &token_validation,
+    )
+    .map_err(|e| CliError::dataerr(format!("Error decoding access token: {e}")))?;
+
+    Ok(token_data)
+}
+
+// Get an access token. If the access token is expired, refresh it.
+#[allow(dead_code)]
+pub(crate) fn get_access_token(console: &AshConsole) -> Result<String, CliError> {
+    // Get the access token from the keyring
+    let access_token = get_keyring_access_token()?;
+
+    // Decode the access token to get its token data
+    let token_data = decode_access_token(&access_token)?;
+
+    // If the access token is expired, refresh it
+    if token_data.claims.exp < (chrono::Utc::now().timestamp() as usize) {
+        refresh_keyring_access_token(console)?;
+        return get_keyring_access_token();
+    }
+
+    Ok(access_token)
+}
+
+// Login to the Ash Console
+#[allow(clippy::unnecessary_to_owned)]
+fn login(config: Option<&str>) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    eprintln!("Logging in to Ash Console at {}", console.api_url);
+
+    console.oauth2.init();
+
+    // Generate the authorization URL and user code
+    let device_authorization = console
+        .oauth2
+        .generate_device_authorization_response(None)
+        .map_err(|e| CliError::dataerr(format!("Error generating authorization URL: {e}")))?;
+
+    println!(
+        "Please open the following URL in your browser:\n{}\nand enter the code: {}",
+        type_colorize(&device_authorization.verification_uri().to_string()),
+        type_colorize(&device_authorization.user_code().secret().to_string())
+    );
+
+    let (access_token, refresh_token) = console
+        .oauth2
+        .exchange_device_code(&device_authorization)
+        .map_err(|e| CliError::dataerr(format!("Error getting access token: {e}")))?;
+
+    // Store the access token and refresh token in the keyring
+    store_keyring_value(
+        KEYRING_TARGET,
+        KEYRING_ACCESS_TOKEN_SERVICE,
+        &access_token.secret().to_string(),
+    )?;
+    store_keyring_value(
+        KEYRING_TARGET,
+        KEYRING_REFRESH_TOKEN_SERVICE,
+        &refresh_token.secret().to_string(),
+    )?;
+
+    println!("\nLogin successful! The credentials have been stored in your device keyring.");
+
+    Ok(())
+}
+
+// Refresh the Ash Console access token
+fn refresh_access_token(config: Option<&str>) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    eprintln!(
+        "Refreshing access token for Ash Console at {}",
+        console.api_url
+    );
+
+    console.oauth2.init();
+
+    refresh_keyring_access_token(&console)?;
+
+    println!("\nAccess token refreshed successfully!");
+
+    Ok(())
+}
+
+// Show the current access token
+fn show_access_token(config: Option<&str>, json: bool) -> Result<(), CliError> {
+    let console = load_console(config)?;
+
+    let access_token = get_keyring_access_token()?;
+
+    eprintln!(
+        "Showing access token for Ash Console at {}",
+        console.api_url
+    );
+
+    let token_data = decode_access_token(&access_token)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({ "accessToken": access_token, "tokenHeader": token_data.header, "tokenClaims": token_data.claims })
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Access token ({}):\n{}",
+        match token_data.claims.exp < (chrono::Utc::now().timestamp() as usize) {
+            true => "expired".red(),
+            false => "valid".green(),
+        },
+        type_colorize(&access_token.to_string()),
+    );
+
+    Ok(())
+}
+
+// Parse console subcommand
+pub(crate) fn parse(auth: AuthCommand, config: Option<&str>, json: bool) -> Result<(), CliError> {
+    match auth.command {
+        AuthSubcommands::Login => login(config),
+        AuthSubcommands::RefreshToken => refresh_access_token(config),
+        AuthSubcommands::ShowToken => show_access_token(config, json),
+    }
+}

--- a/crates/ash_cli/src/main.rs
+++ b/crates/ash_cli/src/main.rs
@@ -3,6 +3,7 @@
 
 mod avalanche;
 mod conf;
+mod console;
 mod utils;
 
 #[macro_use]
@@ -23,7 +24,7 @@ struct Cli {
     /// Output in JSON format
     #[arg(long, short = 'j', global = true, env = "ASH_JSON")]
     json: bool,
-    /// Path to the configuration file
+    /// Path to the CLI configuration file
     #[arg(long, short = 'c', global = true, env = "ASH_CONFIG")]
     config: Option<String>,
 }
@@ -32,6 +33,7 @@ struct Cli {
 enum CliCommands {
     Avalanche(avalanche::AvalancheCommand),
     Conf(conf::ConfCommand),
+    Console(console::ConsoleCommand),
 }
 
 fn main() {
@@ -42,6 +44,7 @@ fn main() {
             avalanche::parse(avalanche, cli.config.as_deref(), cli.json)
         }
         CliCommands::Conf(conf) => conf::parse(conf),
+        CliCommands::Console(console) => console::parse(console, cli.config.as_deref(), cli.json),
     }
     .unwrap_or_else(|e| {
         eprintln!("{}", e.message.red());

--- a/crates/ash_cli/src/utils.rs
+++ b/crates/ash_cli/src/utils.rs
@@ -16,11 +16,7 @@ pub(crate) fn version_tx_cmd(is_tx: bool) -> Str {
 }
 
 /// Store a value in the device keyring
-pub(crate) fn store_keyring_value(
-    target: &str,
-    service: &str,
-    value: &str,
-) -> Result<(), CliError> {
+pub(crate) fn set_keyring_value(target: &str, service: &str, value: &str) -> Result<(), CliError> {
     Entry::new_with_target(target, service, &whoami::username())
         .map_err(|e| CliError::dataerr(format!("Error storing access token: {e}")))?
         .set_password(value)
@@ -33,4 +29,12 @@ pub(crate) fn get_keyring_value(target: &str, service: &str) -> Result<String, C
         .map_err(|e| CliError::dataerr(format!("Error getting access token: {e}")))?
         .get_password()
         .map_err(|e| CliError::dataerr(format!("Error getting access token: {e}")))
+}
+
+/// Remove a value from the device keyring
+pub(crate) fn delete_keyring_value(target: &str, service: &str) -> Result<(), CliError> {
+    Entry::new_with_target(target, service, &whoami::username())
+        .map_err(|e| CliError::dataerr(format!("Error removing access token: {e}")))?
+        .delete_password()
+        .map_err(|e| CliError::dataerr(format!("Error removing access token: {e}")))
 }

--- a/crates/ash_cli/src/utils.rs
+++ b/crates/ash_cli/src/utils.rs
@@ -5,10 +5,32 @@ pub(crate) mod error;
 pub(crate) mod parsing;
 pub(crate) mod templating;
 
+use crate::utils::error::CliError;
 use clap::{builder::Str, crate_version};
+use keyring::Entry;
 
 /// Enrich the version information with whether the command triggers a transaction or not
 /// This is used to help use the CLI in a non-interactive way
 pub(crate) fn version_tx_cmd(is_tx: bool) -> Str {
     Str::from(format!("{} (tx_cmd={})", crate_version!(), is_tx))
+}
+
+/// Store a value in the device keyring
+pub(crate) fn store_keyring_value(
+    target: &str,
+    service: &str,
+    value: &str,
+) -> Result<(), CliError> {
+    Entry::new_with_target(target, service, &whoami::username())
+        .map_err(|e| CliError::dataerr(format!("Error storing access token: {e}")))?
+        .set_password(value)
+        .map_err(|e| CliError::dataerr(format!("Error storing access token: {e}")))
+}
+
+/// Get a value from the device keyring
+pub(crate) fn get_keyring_value(target: &str, service: &str) -> Result<String, CliError> {
+    Entry::new_with_target(target, service, &whoami::username())
+        .map_err(|e| CliError::dataerr(format!("Error getting access token: {e}")))?
+        .get_password()
+        .map_err(|e| CliError::dataerr(format!("Error getting access token: {e}")))
 }

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -40,6 +40,8 @@ chrono = { version = "0.4.24", features = ["clock"] }
 rustls = "0.21.7"
 rustls-pemfile = "1.0.3"
 sha2 = "0.10.7"
+oauth2 = "4.4.2"
+url = "2.4.1"
 
 [dev-dependencies]
 serial_test = "2.0.0"

--- a/crates/ash_sdk/conf/default.yml
+++ b/crates/ash_sdk/conf/default.yml
@@ -123,3 +123,11 @@ avalancheNetworks:
             vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
             rpcUrl: https://ava-testnet.public.blastapi.io/ext/bc/X
+ashConsole:
+  apiUrl: http://localhost:8080
+  oauth2:
+    clientID: cf83e1357eefb8bd
+    authorizationUrl: http://localhost:8090/realms/jeeo/protocol/openid-connect/auth
+    tokenUrl: http://localhost:8090/realms/jeeo/protocol/openid-connect/token
+    tokenIntrospectionUrl: http://localhost:8090/realms/jeeo/protocol/openid-connect/token/introspect
+    deviceAuthorizationUrl: http://localhost:8090/realms/jeeo/protocol/openid-connect/auth/device

--- a/crates/ash_sdk/src/conf.rs
+++ b/crates/ash_sdk/src/conf.rs
@@ -3,7 +3,7 @@
 
 // Module that contains code to interact with the lib configuration
 
-use crate::{avalanche::AvalancheNetwork, errors::*};
+use crate::{avalanche::AvalancheNetwork, console::AshConsole, errors::*};
 use config::{Config, Environment, File, FileFormat};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
@@ -16,6 +16,8 @@ const DEFAULT_CONF: &str = include_str!("../conf/default.yml");
 pub struct AshConfig {
     /// List of known Avalanche networks
     pub avalanche_networks: Vec<AvalancheNetwork>,
+    /// Ash Console configuration
+    pub ash_console: Option<AshConsole>,
 }
 
 impl AshConfig {

--- a/crates/ash_sdk/src/console.rs
+++ b/crates/ash_sdk/src/console.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+pub mod oauth2;
+
+// Module that contains code to interact with the Ash Console
+
+use serde::{Deserialize, Serialize};
+
+use crate::conf::AshConfig;
+use crate::console::oauth2::AshConsoleOAuth2Client;
+use crate::errors::*;
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AshConsole {
+    /// Console URL
+    pub api_url: String,
+    /// Console OAuth2 client
+    pub oauth2: AshConsoleOAuth2Client,
+}
+
+impl AshConsole {
+    /// Load the Ash Console from the configuration
+    pub fn load(config: Option<&str>) -> Result<AshConsole, AshError> {
+        let ash_conf = AshConfig::load(config)?;
+
+        match ash_conf.ash_console {
+            Some(console) => Ok(console),
+            None => Err(ConfigError::NotFound {
+                target_type: "console".to_string(),
+                target_value: "Ash".to_string(),
+            }
+            .into()),
+        }
+    }
+}

--- a/crates/ash_sdk/src/console/oauth2.rs
+++ b/crates/ash_sdk/src/console/oauth2.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+// Module that contains code to interact with the Ash Console OAuth2 provider
+
+use oauth2::{
+    basic::BasicClient, devicecode::StandardDeviceAuthorizationResponse, reqwest::http_client,
+    AccessToken, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
+    DeviceAuthorizationUrl, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope,
+    TokenResponse, TokenUrl,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::errors::*;
+
+/// Ash Console OAuth2 client
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AshConsoleOAuth2Client {
+    /// OAuth2 client
+    #[serde(skip)]
+    pub client: Option<BasicClient>,
+    /// OAuth2 client ID
+    #[serde(rename = "clientID")]
+    pub client_id: ClientId,
+    /// OAuth2 client secret
+    pub client_secret: Option<ClientSecret>,
+    /// OAuth2 authorization URL
+    pub authorization_url: AuthUrl,
+    /// OAuth2 token URL
+    pub token_url: TokenUrl,
+    /// OAuth2 redirect URL
+    pub redirect_url: Option<RedirectUrl>,
+    /// OAuth2 device authorization URL
+    pub device_authorization_url: Option<DeviceAuthorizationUrl>,
+}
+
+impl Default for AshConsoleOAuth2Client {
+    fn default() -> Self {
+        Self {
+            client: None,
+            client_id: ClientId::new("cf83e1357eefb8bd".to_string()),
+            client_secret: None,
+            authorization_url: AuthUrl::new(
+                "http://localhost:8090/realms/jeeo/protocol/openid-connect/auth".to_string(),
+            )
+            .unwrap(),
+            token_url: TokenUrl::new(
+                "http://localhost:8090/realms/jeeo/protocol/openid-connect/token".to_string(),
+            )
+            .unwrap(),
+            redirect_url: Some(RedirectUrl::new("about:blank".to_string()).unwrap()),
+            device_authorization_url: Some(
+                DeviceAuthorizationUrl::new(
+                    "http://localhost:8090/realms/jeeo/protocol/openid-connect/auth/device"
+                        .to_string(),
+                )
+                .unwrap(),
+            ),
+        }
+    }
+}
+
+impl AshConsoleOAuth2Client {
+    /// Initialize the OAuth2 client
+    pub fn init(&mut self) {
+        // Initialize the OAuth2 client
+        let mut client = BasicClient::new(
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            self.authorization_url.clone(),
+            Some(self.token_url.clone()),
+        );
+
+        if let Some(redirect_uri) = &self.redirect_url {
+            client = client.set_redirect_uri(redirect_uri.clone());
+        }
+
+        if let Some(device_authorization_url) = &self.device_authorization_url {
+            client = client.set_device_authorization_url(device_authorization_url.clone());
+        }
+
+        self.client = Some(client);
+    }
+
+    /// Check if the client is initialized
+    pub fn is_initialized(&self) -> Result<(), AshError> {
+        if self.client.is_none() {
+            return Err(ConsoleOAuth2Error::ClientNotInitialized.into());
+        }
+
+        Ok(())
+    }
+
+    /// Generate a full authorization URL with a PKCE challenge and scopes if specified
+    pub fn generate_authorization_code_grant_url(
+        &self,
+        scopes: Option<&str>,
+    ) -> Result<(Url, CsrfToken, PkceCodeVerifier), AshError> {
+        // If redirect URL is not specified, return an error
+        if self.redirect_url.is_none() {
+            return Err(ConsoleOAuth2Error::UrlNotSpecified {
+                url: "redirectUrl".to_string(),
+            }
+            .into());
+        }
+
+        self.is_initialized()?;
+
+        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+        let (auth_url, csrf_token) = self
+            .client
+            .as_ref()
+            .unwrap()
+            .authorize_url(CsrfToken::new_random)
+            .add_scopes(scopes.map(|s| Scope::new(s.to_string())))
+            .set_pkce_challenge(pkce_challenge)
+            .url();
+
+        Ok((auth_url, csrf_token, pkce_verifier))
+    }
+
+    /// Exchange an authorization code for an access token
+    pub fn exchange_authorization_code(
+        &self,
+        authorization_code: &str,
+        pkce_verifier: PkceCodeVerifier,
+    ) -> Result<AccessToken, AshError> {
+        self.is_initialized()?;
+
+        let token = self
+            .client
+            .as_ref()
+            .unwrap()
+            .exchange_code(AuthorizationCode::new(authorization_code.to_string()))
+            .set_pkce_verifier(pkce_verifier)
+            .request(http_client)
+            .map_err(|e| ConsoleOAuth2Error::TokenRequestFailure { msg: e.to_string() })?;
+
+        Ok(token.access_token().clone())
+    }
+
+    /// Generate a device authorization response which contains the verification URL and user code
+    pub fn generate_device_authorization_response(
+        &self,
+        scopes: Option<&str>,
+    ) -> Result<StandardDeviceAuthorizationResponse, AshError> {
+        // If device authorization URL is not specified, return an error
+        if self.device_authorization_url.is_none() {
+            return Err(ConsoleOAuth2Error::UrlNotSpecified {
+                url: "deviceAuthorizationUrl".to_string(),
+            }
+            .into());
+        }
+
+        self.is_initialized()?;
+
+        let details = self
+            .client
+            .as_ref()
+            .unwrap()
+            .exchange_device_code()
+            .map_err(|e| ConsoleOAuth2Error::TokenRequestFailure { msg: e.to_string() })?
+            .add_scopes(scopes.map(|s| Scope::new(s.to_string())))
+            .request(http_client)
+            .map_err(|e| ConsoleOAuth2Error::TokenRequestFailure { msg: e.to_string() })?;
+
+        Ok(details)
+    }
+
+    /// Exchange a device code for an access token
+    pub fn exchange_device_code(
+        &self,
+        device_auth_response: &StandardDeviceAuthorizationResponse,
+    ) -> Result<(AccessToken, RefreshToken), AshError> {
+        self.is_initialized()?;
+
+        let token = self
+            .client
+            .as_ref()
+            .unwrap()
+            .exchange_device_access_token(device_auth_response)
+            .request(http_client, std::thread::sleep, None)
+            .map_err(|e| ConsoleOAuth2Error::TokenRequestFailure { msg: e.to_string() })?;
+
+        Ok((
+            token.access_token().clone(),
+            // Assume that token refresh is allowed
+            token.refresh_token().unwrap().clone(),
+        ))
+    }
+
+    /// Refresh an access token
+    pub fn refresh_access_token(&self, refresh_token_str: &str) -> Result<AccessToken, AshError> {
+        self.is_initialized()?;
+
+        let refresh_token = RefreshToken::new(refresh_token_str.to_string());
+
+        let token = self
+            .client
+            .as_ref()
+            .unwrap()
+            .exchange_refresh_token(&refresh_token)
+            .request(http_client)
+            .map_err(|e| ConsoleOAuth2Error::TokenRequestFailure { msg: e.to_string() })?;
+
+        Ok(token.access_token().clone())
+    }
+}

--- a/crates/ash_sdk/src/errors.rs
+++ b/crates/ash_sdk/src/errors.rs
@@ -26,6 +26,8 @@ pub enum AshError {
     AvalancheNodeError(#[from] AvalancheNodeError),
     #[error("Avalanche Warp Messaging error: {0}")]
     AvalancheWarpMessagingError(#[from] AvalancheWarpMessagingError),
+    #[error("Console OAuth2 error: {0}")]
+    ConsoleOAuth2Error(#[from] ConsoleOAuth2Error),
 }
 
 #[derive(Error, Debug, PartialEq)]
@@ -158,4 +160,16 @@ pub enum AvalancheWarpMessagingError {
     ParseFailure { property: String, msg: String },
     #[error("invalid message signature: {0}")]
     InvalidSignature(String),
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ConsoleOAuth2Error {
+    #[error("failed to parse URL '{url}': {msg}")]
+    UrlParseFailure { url: String, msg: String },
+    #[error("failed to request OAuth2 token: {msg}")]
+    TokenRequestFailure { msg: String },
+    #[error("client is not initialized")]
+    ClientNotInitialized,
+    #[error("'{url}' is not specified")]
+    UrlNotSpecified { url: String },
 }

--- a/crates/ash_sdk/src/lib.rs
+++ b/crates/ash_sdk/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod avalanche;
 pub mod conf;
+pub mod console;
 pub mod errors;
 pub mod utils;
 


### PR DESCRIPTION
### Dependencies

- https://github.com/AshAvalanche/jeeo/pull/20

### Changes

- SDK
  - Add `console` module. For now, it only contains configuration loading logic.
  - Add `ashConsole` to the default configuration:
    ```yaml
    ashConsole:
      apiUrl: http://localhost:8080
      oauth2: {...}
    ```
  - Add `console::oauth2` module that allows authenticating to an OAuth2 server. 2 flows have been implemented: authorization code and device code
- CLI
  - Add the `console auth` subcommand with `login`, `status`, `logout`, `show-token`, and `refresh-token` commands to demonstrate the authentication flow (device code)

### Additional comments

- How to test the new features:
  ```sh
  # Prerequisite: start the Keycloak dev container from the jeeo repo
  
  cargo run -- console auth login
  cargo run -- console auth status
  # Detailed content of the access token (only available in `json` mode)
  cargo run -- console auth show-token --json | jq
  cargo run -- console auth refresh-token
  carfo run -- console auth logout
  ```
- The `refresh-token` will not be super useful in the future as we will refresh the access token in the background. It allows testing that everything works as expected tho.
- Credentials are stored in the device keyring through the [keyring](https://docs.rs/keyring/latest/keyring/) crate that also supports Windows and MacOS.
- I didn't add tests for the `console::oauth2` module as authentication flows are pretty hard to test