### PR TITLE
Node ID generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ version = "0.3.0"
 dependencies = [
  "ash_sdk",
  "async-std",
+ "base64 0.21.4",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "hex",
  "oauth2",
  "openssl",
+ "rcgen 0.11.3",
  "regex",
  "reqwest",
  "rustls",
@@ -855,7 +856,7 @@ dependencies = [
  "log",
  "rand",
  "random-manager",
- "rcgen",
+ "rcgen 0.10.0",
  "rsa",
  "rustls",
  "rustls-pemfile",
@@ -2543,7 +2544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.4",
- "pem",
+ "pem 1.1.1",
  "ring",
  "serde",
  "serde_json",
@@ -3197,6 +3198,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+dependencies = [
+ "base64 0.21.4",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3616,10 +3627,22 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
- "pem",
+ "pem 1.1.1",
  "ring",
  "time",
  "x509-parser 0.14.0",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+dependencies = [
+ "pem 3.0.2",
+ "ring",
+ "time",
  "yasna",
 ]
 

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -32,6 +32,7 @@ whoami = "1.4.1"
 jsonwebtoken = "8.3.0"
 serde = "1.0.188"
 prettytable = "0.10.0"
+base64 = "0.21.4"
 
 [[bin]]
 name = "ash"

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -20,6 +20,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use colored::{ColoredString, Colorize};
 use indoc::formatdoc;
 use prettytable::Table;
+use std::collections::HashMap;
 
 // Module that contains templating functions for info strings
 
@@ -776,6 +777,7 @@ pub(crate) fn template_secrets_table(
         "Name".bold(),
         "Type".bold(),
         "Created at".bold(),
+        "Used by".bold(),
     ]);
 
     for secret in secrets {
@@ -793,6 +795,13 @@ pub(crate) fn template_secrets_table(
                 true => type_colorize(&secret.created.unwrap_or_default()),
                 false => type_colorize(&truncate_datetime(&secret.created.unwrap_or_default())),
             },
+            type_colorize(
+                &serde_json::from_value::<HashMap<String, String>>(
+                    secret.used_by.unwrap_or_default()
+                )
+                .unwrap_or_default()
+                .len()
+            ),
         ]);
     }
 

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -43,6 +43,7 @@ sha2 = "0.10.7"
 oauth2 = "4.4.2"
 url = "2.4.1"
 ash_api = { path = "../../../hai/target/rust" }
+rcgen = "0.11.3"
 
 [dev-dependencies]
 serial_test = "2.0.0"


### PR DESCRIPTION
### Dependencies

- https://github.com/AshAvalanche/jeeo/pull/24

### Changes

- CLI
  - Display secret `usedBy` info (number of times the secret is used)
  - Add `avalanche node generate-id` command that generates a new Node ID with its TLS cert + key pair. ECDSA is used when possible.
  - Support providing `nodeCert` and `nodeKey` as paths when creating a `nodeId` secret. E.g.
    ```bash
    NODE_ID=$(ash avalanche node generate-id -o target/staking --json | jq -r '.nodeID')
    ash console secret create "{\"name\": \"Ash NodeID 1\", \"secretType\": \"nodeId\", \"nodeId\": \"${NODE_ID}\",
    \"nodeCert\": \"target/staking/node.crt\", \"nodeKey\": \"target/staking/node.key\"}"
    ```

### Additional comments

- On MacOS ARM64 (M1/M2), certificates are generated using RSA. See https://github.com/gyuho/cert-manager/blob/1b4211e1606ebfff6d958ba8a6a726fec03db232/src/x509.rs#L465
