### PR TITLE
feat(cli): console region subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "shellexpand",
  "whoami",
 ]
 
@@ -1349,6 +1350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1366,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3128,6 +3150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,6 +4492,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -34,6 +34,7 @@ serde = "1.0.188"
 prettytable = "0.10.0"
 base64 = "0.21.4"
 inquire = "0.6.2"
+shellexpand = "3.1.0"
 
 [[bin]]
 name = "ash"

--- a/crates/ash_cli/src/console.rs
+++ b/crates/ash_cli/src/console.rs
@@ -3,6 +3,7 @@
 
 mod auth;
 mod project;
+mod region;
 mod secret;
 
 // Module that contains the console subcommand parser
@@ -22,6 +23,7 @@ pub(crate) struct ConsoleCommand {
 enum ConsoleSubcommands {
     Auth(auth::AuthCommand),
     Project(project::ProjectCommand),
+    Region(region::RegionCommand),
     Secret(secret::SecretCommand),
 }
 
@@ -51,7 +53,8 @@ pub(crate) fn parse(
 ) -> Result<(), CliError> {
     match console.command {
         ConsoleSubcommands::Auth(auth) => auth::parse(auth, config, json),
-        ConsoleSubcommands::Secret(secret) => secret::parse(secret, config, json),
         ConsoleSubcommands::Project(project) => project::parse(project, config, json),
+        ConsoleSubcommands::Region(region) => region::parse(region, config, json),
+        ConsoleSubcommands::Secret(secret) => secret::parse(secret, config, json),
     }
 }

--- a/crates/ash_cli/src/console/auth.rs
+++ b/crates/ash_cli/src/console/auth.rs
@@ -24,19 +24,19 @@ pub(crate) struct AuthCommand {
 
 #[derive(Subcommand)]
 enum AuthSubcommands {
-    /// Login to the Ash Console. Credentials are stored in the device keyring.
+    /// Login to the Console. Credentials are stored in the device keyring.
     #[command(version = version_tx_cmd(false))]
     Login,
-    /// Refresh the Ash Console access token
+    /// Refresh the Console access token
     #[command(version = version_tx_cmd(false))]
     RefreshToken,
-    /// Show the current Ash Console access token
+    /// Show the current Console access token
     #[command(version = version_tx_cmd(false))]
     ShowToken,
-    /// Logout from the Ash Console. Credentials are removed from the device keyring.
+    /// Logout from the Console. Credentials are removed from the device keyring.
     #[command(version = version_tx_cmd(false))]
     Logout,
-    /// Displays information about the Ash Console authentication state
+    /// Displays information about the Console authentication state
     #[command(version = version_tx_cmd(false))]
     Status,
 }

--- a/crates/ash_cli/src/console/project.rs
+++ b/crates/ash_cli/src/console/project.rs
@@ -34,14 +34,14 @@ enum ProjectSubcommands {
     /// Create a new Console project
     #[command(version = version_tx_cmd(false))]
     Create {
-        /// Secret JSON string
+        /// Project JSON string
         /// e.g.: '{"name": "My project", "network": "local"}'
         project: String,
     },
     /// Show Console project information
     #[command(version = version_tx_cmd(false))]
     Info {
-        /// Secret ID
+        /// Project ID
         project_id: String,
         /// Whether to show extended information (e.g. full IDs)
         #[arg(long, short = 'e')]
@@ -50,15 +50,15 @@ enum ProjectSubcommands {
     /// Update a Console project
     #[command(version = version_tx_cmd(false))]
     Update {
-        /// Secret ID
+        /// Project ID
         project_id: String,
-        /// Secret JSON string
+        /// Project JSON string
         project: String,
     },
     /// Delete a Console project
     #[command(version = version_tx_cmd(false))]
     Delete {
-        /// Secret ID
+        /// Project ID
         project_id: String,
         /// Assume yes to all prompts
         #[arg(long, short = 'y')]
@@ -71,7 +71,7 @@ enum ProjectSubcommands {
     /// This project will be used by default in other commands
     #[command(version = version_tx_cmd(false))]
     Select {
-        /// Secret ID
+        /// Project ID
         project_id: String,
     },
 }
@@ -130,7 +130,22 @@ fn create(project: &str, config: Option<&str>, json: bool) -> Result<(), CliErro
     println!(
         "{}\n{}",
         "Project created successfully!".green(),
-        template_projects_table(vec![response], false, 0)
+        template_projects_table(vec![response.clone()], false, 0)
+    );
+
+    // Set the new project as the current one
+    let mut state = CliState::load()?;
+    state.current_project = Some(response.id.unwrap_or_default().to_string());
+    state.save()?;
+
+    println!(
+        "{}",
+        format!(
+            "Switched to project '{}' ({})!",
+            response.name.unwrap_or_default(),
+            response.id.unwrap_or_default().to_string()
+        )
+        .green()
     );
 
     Ok(())

--- a/crates/ash_cli/src/console/project.rs
+++ b/crates/ash_cli/src/console/project.rs
@@ -260,14 +260,14 @@ fn show(config: Option<&str>, json: bool) -> Result<(), CliError> {
             }
             Err(_) => {
                 eprintln!(
-                    "{}\n{}",
+                    "{}",
                     format!(
                         "The selected project '{}' does not exist anymore.",
-                        project_id
+                        project_id,
                     )
-                    .red(),
-                    "Use `ash project select` to set a new one."
+                    .red()
                 );
+                println!("Use `ash project select` to set a new one.");
             }
         }
     } else {
@@ -313,8 +313,8 @@ fn select(project_id: &str, config: Option<&str>, json: bool) -> Result<(), CliE
         "{}",
         format!(
             "Switched to project '{}' ({})!",
-            current_project.name.unwrap_or_default().to_string(),
-            current_project.id.unwrap_or_default().to_string()
+            current_project.name.unwrap_or_default(),
+            current_project.id.unwrap_or_default()
         )
         .green()
     );

--- a/crates/ash_cli/src/console/region.rs
+++ b/crates/ash_cli/src/console/region.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+// Module that contains the region subcommand parser
+
+use crate::{
+    console::project::get_current_project_id,
+    console::{create_api_config_with_access_token, load_console},
+    utils::{error::CliError, prompt::confirm_deletion, templating::*, version_tx_cmd},
+};
+use ash_sdk::console;
+use async_std::task;
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+
+/// Interact with Ash Console projects' cloud regions
+#[derive(Parser)]
+#[command()]
+pub(crate) struct RegionCommand {
+    #[command(subcommand)]
+    command: RegionSubcommands,
+    /// Console project ID.
+    /// Defaults to the current project
+    #[arg(
+        long,
+        short = 'p',
+        default_value = "current",
+        global = true,
+        env = "ASH_CONSOLE_PROJECT"
+    )]
+    project: String,
+}
+
+#[derive(Subcommand)]
+enum RegionSubcommands {
+    /// Show the list of available regions for each cloud provider
+    #[command(version = version_tx_cmd(false))]
+    Available,
+    /// List the cloud regions of the Console project
+    #[command(version = version_tx_cmd(false))]
+    List {
+        /// Whether to show extended information (e.g. full IDs)
+        #[arg(long, short = 'e')]
+        extended: bool,
+    },
+    /// Add a cloud region to the Console project
+    #[command(version = version_tx_cmd(false))]
+    Add {
+        /// Cloud region JSON string
+        /// e.g.: '{"cloudProvider": "aws", "region": "us-east-1", "cloudCredentialsSecretId": "secret-id"}'
+        region: String,
+    },
+    /// Show information about a cloud region of the Console project
+    #[command(version = version_tx_cmd(false))]
+    Info {
+        /// Region name
+        /// e.g.: "aws/us-east-1"
+        region_name: String,
+        /// Whether to show extended information (e.g. full IDs)
+        #[arg(long, short = 'e')]
+        extended: bool,
+    },
+    /// Remove a cloud region from the Console project
+    #[command(version = version_tx_cmd(false))]
+    Remove {
+        /// Region name
+        /// e.g.: "aws/us-east-1"
+        region_name: String,
+        /// Assume yes to all prompts
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+}
+
+// List available cloud regions of a provider
+fn available(config: Option<&str>, json: bool) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    let response =
+        task::block_on(async { console::api::get_available_cloud_regions(&api_config).await })
+            .map_err(|e| {
+                CliError::dataerr(format!("Error getting available cloud regions: {e}"))
+            })?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "Available cloud regions:\n{}",
+        template_available_regions_table(response, 0)
+    );
+
+    Ok(())
+}
+
+// List cloud regions of a project
+fn list(
+    project_id: &str,
+    extended: bool,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    let response = task::block_on(async {
+        console::api::get_all_project_cloud_regions(&api_config, project_id).await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error getting project cloud regions: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "Cloud regions of project '{}':\n{}",
+        type_colorize(&project_id),
+        template_regions_table(response, extended, 0)
+    );
+
+    Ok(())
+}
+
+// Add a cloud region to a project
+fn add(project_id: &str, region: &str, config: Option<&str>, json: bool) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    // Deserialize the region JSON
+    let new_region: console::api_models::NewCloudRegion = serde_json::from_str(region)
+        .map_err(|e| CliError::dataerr(format!("Error parsing cloud region JSON: {e}")))?;
+
+    let response = task::block_on(async {
+        console::api::add_project_cloud_region(&api_config, project_id, new_region).await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error adding cloud region to the project: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "{}\n{}",
+        format!(
+            "Cloud region successfully added to project '{}'!",
+            project_id
+        )
+        .green(),
+        template_regions_table(vec![response], false, 0)
+    );
+
+    Ok(())
+}
+
+// Get a project cloud region information by its ID
+fn show(
+    project_id: &str,
+    region_name: &str,
+    extended: bool,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    let response = task::block_on(async {
+        console::api::get_project_cloud_region_by_name(
+            &api_config,
+            project_id,
+            &region_name.replace("/", "_"),
+        )
+        .await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error getting cloud region: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "{}\n{}",
+        format!(
+            "Region '{}' of project '{}':",
+            type_colorize(&region_name),
+            type_colorize(&project_id)
+        ),
+        template_regions_table(vec![response], extended, 0)
+    );
+
+    Ok(())
+}
+
+// Remove a cloud region from a project
+fn remove(
+    project_id: &str,
+    region_name: &str,
+    yes: bool,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    // Prompt for confirmation if not using --yes
+    if !yes {
+        show(project_id, region_name, false, config, false)?;
+
+        if !confirm_deletion("region", Some("remove")) {
+            return Ok(());
+        }
+    }
+
+    let response = task::block_on(async {
+        console::api::remove_project_cloud_region_by_name(
+            &api_config,
+            project_id,
+            &region_name.replace("/", "_"),
+        )
+        .await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error removing cloud region: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!("{}", "Cloud region removed successfully!".green());
+
+    Ok(())
+}
+
+// Parse region subcommand
+pub(crate) fn parse(
+    region: RegionCommand,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut project_id = region.project;
+
+    // Get the current project ID for the subcommands that require it
+    match region.command {
+        RegionSubcommands::Available {} => (),
+        _ => {
+            if project_id == "current" {
+                project_id = get_current_project_id()?;
+            }
+        }
+    }
+
+    match region.command {
+        RegionSubcommands::Available => available(config, json),
+        RegionSubcommands::List { extended } => list(&project_id, extended, config, json),
+        RegionSubcommands::Add { region } => add(&project_id, &region, config, json),
+        RegionSubcommands::Info {
+            region_name,
+            extended,
+        } => show(&project_id, &region_name, extended, config, json),
+        RegionSubcommands::Remove { region_name, yes } => {
+            remove(&project_id, &region_name, yes, config, json)
+        }
+    }
+}

--- a/crates/ash_cli/src/console/region.rs
+++ b/crates/ash_cli/src/console/region.rs
@@ -176,7 +176,7 @@ fn show(
         console::api::get_project_cloud_region_by_name(
             &api_config,
             project_id,
-            &region_name.replace("/", "_"),
+            &region_name.replace('/', "_"),
         )
         .await
     })
@@ -188,12 +188,9 @@ fn show(
     }
 
     println!(
-        "{}\n{}",
-        format!(
-            "Region '{}' of project '{}':",
-            type_colorize(&region_name),
-            type_colorize(&project_id)
-        ),
+        "Region '{}' of project '{}':\n{}",
+        type_colorize(&region_name),
+        type_colorize(&project_id),
         template_regions_table(vec![response], extended, 0)
     );
 
@@ -225,7 +222,7 @@ fn remove(
         console::api::remove_project_cloud_region_by_name(
             &api_config,
             project_id,
-            &region_name.replace("/", "_"),
+            &region_name.replace('/', "_"),
         )
         .await
     })

--- a/crates/ash_cli/src/utils.rs
+++ b/crates/ash_cli/src/utils.rs
@@ -5,6 +5,7 @@ pub(crate) mod error;
 pub(crate) mod keyring;
 pub(crate) mod parsing;
 pub(crate) mod prompt;
+pub(crate) mod state;
 pub(crate) mod templating;
 
 use clap::{builder::Str, crate_version};

--- a/crates/ash_cli/src/utils/prompt.rs
+++ b/crates/ash_cli/src/utils/prompt.rs
@@ -1,9 +1,14 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
 use colored::Colorize;
 use inquire::Confirm;
 
-pub(crate) fn confirm_deletion(object_type: &str) -> bool {
+pub(crate) fn confirm_deletion(object_type: &str, action: Option<&str>) -> bool {
+    let action = action.unwrap_or("delete");
+
     let confirmation = Confirm::new(&format!(
-        "Are you sure you want to delete this {object_type}?"
+        "Are you sure you want to {action} this {object_type}?"
     ))
     .with_default(false)
     .with_help_message("This action is irreversible!")

--- a/crates/ash_cli/src/utils/state.rs
+++ b/crates/ash_cli/src/utils/state.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+use serde::{Deserialize, Serialize};
+use std::{fs, path::Path};
+
+use crate::utils::error::CliError;
+
+pub const ASH_CLI_STATE_FILE: &str = "~/.local/state/ash/state.json";
+
+/// Ash CLI state to be stored in a JSON file
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliState {
+    pub(crate) current_project: Option<String>,
+}
+
+impl CliState {
+    /// Load the CLI state from the state file
+    pub(crate) fn load() -> Result<Self, CliError> {
+        let state_file = shellexpand::tilde(ASH_CLI_STATE_FILE).to_string();
+        let state_file = Path::new(&state_file);
+
+        if !state_file.exists() {
+            return Ok(Self::default());
+        }
+
+        let state_file = fs::File::open(state_file)
+            .map_err(|e| CliError::dataerr(format!("Error opening state file: {e}")))?;
+        let state: Self = serde_json::from_reader(state_file)
+            .map_err(|e| CliError::dataerr(format!("Error parsing state file: {e}")))?;
+
+        Ok(state)
+    }
+
+    /// Save the CLI state to the state file
+    pub(crate) fn save(&self) -> Result<(), CliError> {
+        let state_file = shellexpand::tilde(ASH_CLI_STATE_FILE).to_string();
+        let state_file = Path::new(&state_file);
+
+        // Create the state file parent directory if it doesn't exist
+        if let Some(parent) = state_file.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent)
+                    .map_err(|e| CliError::dataerr(format!("Error creating state file: {e}")))?;
+            }
+        }
+
+        let state_file = fs::File::create(state_file)
+            .map_err(|e| CliError::dataerr(format!("Error creating state file: {e}")))?;
+        serde_json::to_writer_pretty(state_file, self)
+            .map_err(|e| CliError::dataerr(format!("Error writing state file: {e}")))?;
+
+        Ok(())
+    }
+}

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -19,7 +19,7 @@ use ash_sdk::{
 use chrono::{DateTime, NaiveDateTime, Utc};
 use colored::{ColoredString, Colorize};
 use indoc::formatdoc;
-use prettytable::Table;
+use prettytable::{format, Table};
 use std::collections::HashMap;
 
 // Module that contains templating functions for info strings
@@ -815,16 +815,29 @@ pub(crate) fn template_projects_table(
 ) -> String {
     let mut projects_table = Table::new();
 
-    // TODO: Display information about the project's cloud regions
     projects_table.set_titles(row![
         "Project ID".bold(),
         "Owner ID".bold(),
         "Name".bold(),
         "Network".bold(),
+        "Cloud regions".bold(),
         "Created at".bold(),
     ]);
 
     for project in projects {
+        let mut regions_table = Table::new();
+        regions_table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+
+        for (region_name, _) in project
+            .cloud_regions_ids
+            .clone()
+            .unwrap_or_default()
+            .as_object()
+            .unwrap()
+        {
+            regions_table.add_row(row![type_colorize(&region_name),]);
+        }
+
         projects_table.add_row(row![
             type_colorize(&project.id.unwrap_or_default()),
             match extended {
@@ -835,6 +848,7 @@ pub(crate) fn template_projects_table(
             },
             type_colorize(&project.name.unwrap_or_default()),
             type_colorize(&format!("{:?}", project.network.unwrap_or_default())),
+            regions_table,
             match extended {
                 true => type_colorize(&project.created.unwrap_or_default()),
                 false => type_colorize(&truncate_datetime(&project.created.unwrap_or_default())),
@@ -843,4 +857,73 @@ pub(crate) fn template_projects_table(
     }
 
     indent::indent_all_by(indent, projects_table.to_string())
+}
+
+pub(crate) fn template_regions_table(
+    regions: Vec<console::api_models::CloudRegion>,
+    extended: bool,
+    indent: usize,
+) -> String {
+    let mut regions_table = Table::new();
+
+    regions_table.set_titles(row![
+        "Cloud provider".bold(),
+        "Cloud region".bold(),
+        "Region ID".bold(),
+        "Cloud creds secret ID".bold(),
+        "Created at".bold(),
+    ]);
+
+    for region in regions {
+        regions_table.add_row(row![
+            type_colorize(
+                &serde_json::to_value(&region.cloud_provider.unwrap_or_default())
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+            ),
+            type_colorize(&region.region.unwrap_or_default()),
+            match extended {
+                true => type_colorize(&region.id.unwrap_or_default()),
+                false => type_colorize(&truncate_uuid(&region.id.unwrap_or_default().to_string())),
+            },
+            match extended {
+                true => type_colorize(&region.cloud_credentials_secret_id.unwrap_or_default()),
+                false => type_colorize(&truncate_uuid(
+                    &region
+                        .cloud_credentials_secret_id
+                        .unwrap_or_default()
+                        .to_string()
+                )),
+            },
+            match extended {
+                true => type_colorize(&region.created.unwrap_or_default()),
+                false => type_colorize(&truncate_datetime(&region.created.unwrap_or_default())),
+            },
+        ]);
+    }
+
+    indent::indent_all_by(indent, regions_table.to_string())
+}
+
+pub(crate) fn template_available_regions_table(
+    provider_regions: serde_json::Value,
+    indent: usize,
+) -> String {
+    let mut provider_regions_table = Table::new();
+
+    provider_regions_table.set_titles(row!["Cloud provider".bold(), "Available regions".bold(),]);
+
+    for provider in provider_regions.as_object().unwrap() {
+        let mut regions_table = Table::new();
+        regions_table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+
+        for region in provider.1.as_array().unwrap() {
+            regions_table.add_row(row![&region.as_str().unwrap_or_default(),]);
+        }
+
+        provider_regions_table.add_row(row![&provider.0, regions_table,]);
+    }
+
+    indent::indent_all_by(indent, provider_regions_table.to_string())
 }

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -877,7 +877,7 @@ pub(crate) fn template_regions_table(
     for region in regions {
         regions_table.add_row(row![
             type_colorize(
-                &serde_json::to_value(&region.cloud_provider.unwrap_or_default())
+                &serde_json::to_value(region.cloud_provider.unwrap_or_default())
                     .unwrap()
                     .as_str()
                     .unwrap()


### PR DESCRIPTION
### Dependencies

- https://github.com/AshAvalanche/jeeo/pull/33

### Changes

- CLI
  - Rename `console ... show` subcommands to `console ... info` out of coherence with `avalanche` commands
  - Add `show` and `select` subcommands to `console project`. This allows to select the current project that will be used by default in other subcommands like `console region ...`
    ```bash
    cargo run -- console project show
    cargo run -- console project select $PROJECT_ID
    cargo run -- console project show
    ```
  - Add the `Cloud regions` column to the `console project` subcommands output table
  - Add the `console region` subcommands: `available`, `list`, `add`, `info`, `remove`
    ```bash
    cargo run -- console region available
    cargo run -- console region add '{"cloudProvider": "aws", "region": "us-east-2", "cloudCredentialsSecretId": "$SECRET_ID"}'
    cargo run -- console region list
    cargo run -- console region info aws/us-east-2
    cargo run -- console region remove aws/us-east-2
    ```

### Additional comments

- The current project is stored at `~/.local/state/ash/state.json` which seems to be good practice on Linux/MacOS
- As usual, users get more information when using `--json`
