### PR TITLE
feat(cli): add ash console resource subcommands

### DIFF
--- a/crates/ash_cli/src/console.rs
+++ b/crates/ash_cli/src/console.rs
@@ -5,6 +5,7 @@ mod auth;
 mod operation;
 mod project;
 mod region;
+mod resource;
 mod secret;
 
 // Module that contains the console subcommand parser
@@ -26,6 +27,7 @@ enum ConsoleSubcommands {
     Operation(operation::OperationCommand),
     Project(project::ProjectCommand),
     Region(region::RegionCommand),
+    Resource(resource::ResourceCommand),
     Secret(secret::SecretCommand),
 }
 
@@ -58,6 +60,7 @@ pub(crate) fn parse(
         ConsoleSubcommands::Operation(operation) => operation::parse(operation, config, json),
         ConsoleSubcommands::Project(project) => project::parse(project, config, json),
         ConsoleSubcommands::Region(region) => region::parse(region, config, json),
+        ConsoleSubcommands::Resource(resource) => resource::parse(resource, config, json),
         ConsoleSubcommands::Secret(secret) => secret::parse(secret, config, json),
     }
 }

--- a/crates/ash_cli/src/console/project.rs
+++ b/crates/ash_cli/src/console/project.rs
@@ -124,29 +124,31 @@ fn create(project: &str, config: Option<&str>, json: bool) -> Result<(), CliErro
 
     if json {
         println!("{}", serde_json::json!(&response));
-        return Ok(());
+    } else {
+        println!(
+            "{}\n{}",
+            "Project created successfully!".green(),
+            template_projects_table(vec![response.clone()], false, 0)
+        );
     }
-
-    println!(
-        "{}\n{}",
-        "Project created successfully!".green(),
-        template_projects_table(vec![response.clone()], false, 0)
-    );
 
     // Set the new project as the current one
     let mut state = CliState::load()?;
     state.current_project = Some(response.id.unwrap_or_default().to_string());
     state.save()?;
 
-    println!(
-        "{}",
-        format!(
-            "Switched to project '{}' ({})!",
-            response.name.unwrap_or_default(),
-            response.id.unwrap_or_default().to_string()
-        )
-        .green()
-    );
+    let switch_message = format!(
+        "Switched to project '{}' ({})!",
+        response.name.unwrap_or_default(),
+        response.id.unwrap_or_default().to_string()
+    )
+    .green();
+
+    if json {
+        eprint!("{}", switch_message);
+    } else {
+        println!("{}", switch_message);
+    }
 
     Ok(())
 }

--- a/crates/ash_cli/src/console/resource.rs
+++ b/crates/ash_cli/src/console/resource.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+// Module that contains the resource subcommand parser
+
+use crate::{
+    console::project::get_current_project_id,
+    console::{create_api_config_with_access_token, load_console},
+    utils::{error::CliError, prompt::confirm_deletion, templating::*, version_tx_cmd},
+};
+use ash_sdk::console;
+use async_std::task;
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+
+/// Interact with Ash Console projects' resources
+#[derive(Parser)]
+#[command()]
+pub(crate) struct ResourceCommand {
+    #[command(subcommand)]
+    command: ResourceSubcommands,
+    /// Console project ID.
+    /// Defaults to the current project
+    #[arg(
+        long,
+        short = 'p',
+        default_value = "current",
+        global = true,
+        env = "ASH_CONSOLE_PROJECT"
+    )]
+    project: String,
+}
+
+#[derive(Subcommand)]
+enum ResourceSubcommands {
+    /// List the resources of the Console project
+    #[command(version = version_tx_cmd(false))]
+    List {
+        /// Whether to show extended information (e.g. full IDs)
+        #[arg(long, short = 'e')]
+        extended: bool,
+    },
+    /// Create a resource in the Console project
+    #[command(version = version_tx_cmd(false))]
+    Create {
+        /// Resource JSON string
+        /// e.g.: '{"name": "my-node", "resourceType": "avalancheNode", "cloudRegionId": "region-id", ...}'
+        resource: String,
+    },
+    /// Show information about a resource of the Console project
+    #[command(version = version_tx_cmd(false))]
+    Info {
+        /// Resource ID
+        resource_id: String,
+        /// Whether to show extended information (e.g. full IDs)
+        #[arg(long, short = 'e')]
+        extended: bool,
+    },
+    /// Update a resource of the Console project
+    #[command(version = version_tx_cmd(false))]
+    Update {
+        /// Resource ID
+        resource_id: String,
+        /// Resource JSON string
+        /// e.g.: '{"name": "my-node", "resourceType": "avalancheNode", "cloudRegionId": "region-id", ...}'
+        resource: String,
+    },
+    /// Delete a resource from the Console project
+    #[command(version = version_tx_cmd(false))]
+    Delete {
+        /// Resource ID
+        resource_id: String,
+        /// Assume yes to all prompts
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+}
+
+// List resources of a project
+fn list(
+    project_id: &str,
+    extended: bool,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    let response = task::block_on(async {
+        console::api::get_all_project_resources(&api_config, project_id).await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error getting project resources: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "Resources of project '{}':\n{}",
+        type_colorize(&project_id),
+        template_resources_table(response, extended, 0)
+    );
+
+    Ok(())
+}
+
+// Create a resource in a project
+fn create(
+    project_id: &str,
+    resource: &str,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    // Deserialize the resource JSON
+    // TODO: Change to CreateResourceRequest when another resource type is added
+    let new_resource: console::api_models::NewAvalancheNodeResource =
+        serde_json::from_str(resource)
+            .map_err(|e| CliError::dataerr(format!("Error parsing resource JSON: {e}")))?;
+
+    let response = task::block_on(async {
+        console::api::create_project_resource(&api_config, project_id, new_resource).await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error creating resource in the project: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "{}\n{}",
+        format!("Resource successfully added to project '{}'!", project_id).green(),
+        template_resources_table(vec![response], false, 0)
+    );
+
+    Ok(())
+}
+
+// Get a project resource information by its ID
+fn info(
+    project_id: &str,
+    resource_id: &str,
+    extended: bool,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    let response = task::block_on(async {
+        console::api::get_project_resource_by_id(&api_config, project_id, &resource_id).await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error getting resource: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "Resource '{}' of project '{}':\n{}",
+        type_colorize(&resource_id),
+        type_colorize(&project_id),
+        template_resources_table(vec![response], extended, 0)
+    );
+
+    Ok(())
+}
+
+// Update a resource
+fn update(
+    project_id: &str,
+    resource_id: &str,
+    resource: &str,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    // Deserialize the resource JSON
+    // TODO: Change to UpdateResourceByIdRequest when another resource type is added
+    let update_resource_request: console::api_models::UpdateAvalancheNodeResource =
+        serde_json::from_str(resource)
+            .map_err(|e| CliError::dataerr(format!("Error parsing resource JSON: {e}")))?;
+
+    let response = task::block_on(async {
+        console::api::update_project_resource_by_id(
+            &api_config,
+            project_id,
+            resource_id,
+            update_resource_request,
+        )
+        .await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error updating resource: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!(
+        "{}\n{}",
+        "Resource updated successfully!".green(),
+        template_resources_table(vec![response], false, 0)
+    );
+
+    Ok(())
+}
+
+// Delete a resource from a project
+fn delete(
+    project_id: &str,
+    resource_id: &str,
+    yes: bool,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut console = load_console(config)?;
+
+    let api_config = create_api_config_with_access_token(&mut console)?;
+
+    // Prompt for confirmation if not using --yes
+    if !yes {
+        info(project_id, resource_id, false, config, false)?;
+
+        if !confirm_deletion("resource", None) {
+            return Ok(());
+        }
+    }
+
+    let response = task::block_on(async {
+        console::api::delete_project_resource_by_id(&api_config, project_id, &resource_id).await
+    })
+    .map_err(|e| CliError::dataerr(format!("Error removing resource: {e}")))?;
+
+    if json {
+        println!("{}", serde_json::json!(&response));
+        return Ok(());
+    }
+
+    println!("{}", "Cloud resource removed successfully!".green());
+
+    Ok(())
+}
+
+// Parse resource subcommand
+pub(crate) fn parse(
+    resource: ResourceCommand,
+    config: Option<&str>,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut project_id = resource.project;
+
+    // Get the current project ID for the subcommands that require it
+    match resource.command {
+        _ => {
+            if project_id == "current" {
+                project_id = get_current_project_id()?;
+            }
+        }
+    }
+
+    match resource.command {
+        ResourceSubcommands::List { extended } => list(&project_id, extended, config, json),
+        ResourceSubcommands::Create { resource } => create(&project_id, &resource, config, json),
+        ResourceSubcommands::Info {
+            resource_id,
+            extended,
+        } => info(&project_id, &resource_id, extended, config, json),
+        ResourceSubcommands::Update {
+            resource_id,
+            resource,
+        } => update(&project_id, &resource_id, &resource, config, json),
+        ResourceSubcommands::Delete { resource_id, yes } => {
+            delete(&project_id, &resource_id, yes, config, json)
+        }
+    }
+}

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -875,15 +875,16 @@ pub(crate) fn template_regions_table(
     let mut regions_table = Table::new();
 
     regions_table.set_titles(row![
+        "Region ID".bold(),
         "Cloud provider".bold(),
         "Cloud region".bold(),
-        "Region ID".bold(),
         "Cloud creds secret ID".bold(),
         "Created at".bold(),
     ]);
 
     for region in regions {
         regions_table.add_row(row![
+            type_colorize(&region.id.unwrap_or_default()),
             type_colorize(
                 &serde_json::to_value(region.cloud_provider.unwrap_or_default())
                     .unwrap()
@@ -891,10 +892,6 @@ pub(crate) fn template_regions_table(
                     .unwrap()
             ),
             type_colorize(&region.region.unwrap_or_default()),
-            match extended {
-                true => type_colorize(&region.id.unwrap_or_default()),
-                false => type_colorize(&truncate_uuid(&region.id.unwrap_or_default().to_string())),
-            },
             match extended {
                 true => type_colorize(&region.cloud_credentials_secret_id.unwrap_or_default()),
                 false => type_colorize(&truncate_uuid(
@@ -983,6 +980,51 @@ pub(crate) fn template_operations_table(
             match operation.result.unwrap_or_default() {
                 console::api_models::operation::Result::Success => "Success".green(),
                 console::api_models::operation::Result::Failure => "Failure".red(),
+            },
+        ]);
+    }
+
+    indent::indent_all_by(indent, operations_table.to_string())
+}
+
+pub(crate) fn template_resources_table(
+    resources: Vec<console::api_models::GetAllProjectResources200ResponseInner>,
+    extended: bool,
+    indent: usize,
+) -> String {
+    use console::api_models::get_all_project_resources_200_response_inner::Status;
+
+    let mut operations_table = Table::new();
+
+    operations_table.set_titles(row![
+        "Resource ID".bold(),
+        "Name".bold(),
+        "Type".bold(),
+        "Cloud region ID".bold(),
+        "Created at".bold(),
+        "Status".bold(),
+    ]);
+
+    for operation in resources {
+        operations_table.add_row(row![
+            type_colorize(&operation.id.unwrap_or_default()),
+            type_colorize(&operation.name.unwrap_or_default()),
+            type_colorize(&format!(
+                "{:?}",
+                operation.resource_type.unwrap_or_default()
+            )),
+            type_colorize(&operation.cloud_region_id.unwrap_or_default()),
+            match extended {
+                true => type_colorize(&operation.created.unwrap_or_default()),
+                false => type_colorize(&truncate_datetime(&operation.created.unwrap_or_default())),
+            },
+            match operation.status.unwrap_or_default() {
+                Status::Pending => "Pending".yellow(),
+                Status::Configuring => "Configuring".blue(),
+                Status::Running => "Running".green(),
+                Status::Error => "Error".red(),
+                Status::Destroying => "Destroying".yellow(),
+                Status::Stopped => "Stopped".bright_black(),
             },
         ]);
     }


### PR DESCRIPTION
### Dependencies

- https://github.com/AshAvalanche/hai/pull/37
- https://github.com/AshAvalanche/jeeo/pull/48

### Changes

- CLI
  - Add `console resource` subcommands: `list`, `create`, `info`, `update`, and `delete`

### Additional comments

- The `update` subcommand will always fail since the update endpoint isn't implemented in `jeeo`