### PR TITLE
feat: bump ash-api-rs to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "ash_api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "reqwest",
  "serde",

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -42,7 +42,7 @@ rustls-pemfile = "1.0.3"
 sha2 = "0.10.7"
 oauth2 = "4.4.2"
 url = "2.4.1"
-ash_api = { path = "../../../hai/ash-api-rs", version = "0.1.1" }
+ash_api = { path = "../../../hai/ash-api-rs", version = "0.1.2" }
 rcgen = "0.11.3"
 
 [dev-dependencies]


### PR DESCRIPTION
### Dependencies

- https://github.com/AshAvalanche/jeeo/pull/100
- https://github.com/AshAvalanche/ash-api-rs/pull/2

### Changes

- Update `ash-api-rs`
