### PR TITLE
feat(console): support for YAML files/strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ version = "0.4.0-alpha.4"
 dependencies = [
  "ash_sdk",
  "async-std",
+ "atty",
  "base64 0.21.4",
  "chrono",
  "clap",
@@ -193,6 +194,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_yaml",
  "shellexpand",
  "whoami",
 ]
@@ -477,6 +479,17 @@ name = "atomic-waker"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "auto_impl"
@@ -2260,6 +2273,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -2542,7 +2564,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys",
 ]
@@ -2559,7 +2581,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "rustix 0.38.13",
  "windows-sys",
 ]
@@ -2995,7 +3017,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -4313,9 +4335,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -4333,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4426,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -35,6 +35,8 @@ prettytable = "0.10.0"
 base64 = "0.21.4"
 inquire = "0.6.2"
 shellexpand = "3.1.0"
+serde_yaml = "0.9.27"
+atty = "0.2.14"
 
 [[bin]]
 name = "ash"

--- a/crates/ash_cli/src/utils.rs
+++ b/crates/ash_cli/src/utils.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2023, E36 Knots
 
 pub(crate) mod error;
+pub(crate) mod file;
 pub(crate) mod keyring;
 pub(crate) mod parsing;
 pub(crate) mod prompt;

--- a/crates/ash_cli/src/utils/file.rs
+++ b/crates/ash_cli/src/utils/file.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, E36 Knots
+
+// Module that contains file utility functions
+
+use crate::utils::error::CliError;
+use atty::Stream;
+use base64::{engine, Engine};
+use std::{
+    fs,
+    io::{stdin, Read},
+    path::PathBuf,
+};
+
+// Read a file and return its content as a string
+pub(crate) fn read_file(file_path: PathBuf) -> Result<String, CliError> {
+    let file_content = fs::read_to_string(file_path)
+        .map_err(|e| CliError::dataerr(format!("Error reading file: {e}")))?;
+
+    Ok(file_content)
+}
+
+// Read a file and return its content as a Base64-encoded string
+pub(crate) fn read_file_base64(file_path: PathBuf) -> Result<String, CliError> {
+    let file_content = read_file(file_path)?;
+
+    Ok(engine::general_purpose::STANDARD.encode(file_content))
+}
+
+// Read content from stdin and return it as a string
+pub(crate) fn read_stdin() -> Result<String, CliError> {
+    let mut content = String::new();
+
+    // Fail if stdin is a TTY
+    if atty::is(Stream::Stdin) {
+        return Err(CliError::dataerr(
+            "Error reading from stdin: stdin was not redirected".to_string(),
+        ));
+    }
+
+    stdin()
+        .read_to_string(&mut content)
+        .map_err(|e| CliError::dataerr(format!("Error reading stdin: {e}")))?;
+
+    Ok(content)
+}
+
+// Read content from a file or stdin or return the input string unchanged
+pub(crate) fn read_file_or_stdin(input_str: &str) -> Result<String, CliError> {
+    let file_path = PathBuf::from(input_str);
+
+    let output_str = if file_path.exists() {
+        read_file(file_path)?
+    } else {
+        if input_str == "-" {
+            read_stdin()?
+        } else {
+            input_str.to_string()
+        }
+    };
+
+    Ok(output_str)
+}


### PR DESCRIPTION
### Changes

- Allow to specify entities config as a YAML (or JSON) file or string. Also support reading from `stdin`.  
  Example:
  ```sh
  cargo run -- console project create '{name: my-project, network: local}'
  ```
