### PR TITLE
feat: add support for node BLS key and pop

### DIFF
--- a/crates/ash_cli/src/avalanche/node.rs
+++ b/crates/ash_cli/src/avalanche/node.rs
@@ -249,7 +249,7 @@ fn pop_from_bls_key(
             .map_err(|e| CliError::dataerr(format!("Error reading BLS key file: {e}")))?,
         _ => {
             return Err(CliError::dataerr(
-                "Error when parsing arguments: either 'key' or 'key-file' must be provided"
+                "Error when parsing arguments: either 'key-str' or 'key-file' must be provided"
                     .to_string(),
             ))
         }

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -449,6 +449,9 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: usize) 
         "
         Node '{}:{}':
           ID:            {}
+          Signer (BLS):
+            Public key:  {}
+            PoP:         {}
           Network:       {}
           Public IP:     {}
           Staking port:  {}
@@ -468,6 +471,14 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: usize) 
         type_colorize(&node.http_host),
         type_colorize(&node.http_port),
         type_colorize(&node.id),
+        type_colorize(&match node.signer {
+            Some(ref signer) => format!("0x{}", hex::encode(&signer.public_key.clone())),
+            None => String::from("None"),
+        }),
+        type_colorize(&match node.signer {
+            Some(ref signer) => format!("0x{}", hex::encode(&signer.proof_of_possession.clone())),
+            None => String::from("None"),
+        }),
         type_colorize(&node.network),
         type_colorize(&node.public_ip),
         type_colorize(&node.staking_port),

--- a/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/info.rs
@@ -12,6 +12,7 @@ use crate::{
 use avalanche_types::{
     ids::node::Id as NodeId,
     jsonrpc::{info::*, ResponseError},
+    key::bls::ProofOfPossession,
 };
 use std::net::SocketAddr;
 
@@ -27,15 +28,14 @@ impl_json_rpc_response!(IsBootstrappedResponse, IsBootstrappedResult);
 impl_json_rpc_response!(PeersResponse, PeersResult);
 
 /// Get the ID of a node by querying the Info API
-pub fn get_node_id(rpc_url: &str) -> Result<NodeId, RpcError> {
+pub fn get_node_id(rpc_url: &str) -> Result<(NodeId, Option<ProofOfPossession>), RpcError> {
     let node_id = get_json_rpc_req_result::<GetNodeIdResponse, GetNodeIdResult>(
         rpc_url,
         "info.getNodeID",
         None,
-    )?
-    .node_id;
+    )?;
 
-    Ok(node_id)
+    Ok((node_id.node_id, node_id.node_pop))
 }
 
 /// Get the IP of a node by querying the Info API
@@ -134,7 +134,7 @@ mod tests {
             "http://{}:{}/{}",
             ASH_TEST_HTTP_HOST, ASH_TEST_HTTP_PORT, AVAX_INFO_API_ENDPOINT
         );
-        let node_id = get_node_id(&rpc_url).unwrap();
+        let (node_id, _) = get_node_id(&rpc_url).unwrap();
         assert_eq!(node_id, NodeId::from_str(ASH_TEST_NODE_ID).unwrap());
     }
 

--- a/crates/ash_sdk/src/errors.rs
+++ b/crates/ash_sdk/src/errors.rs
@@ -152,6 +152,8 @@ pub enum AvalancheVMError {
 pub enum AvalancheNodeError {
     #[error("invalid node certificate: {0}")]
     InvalidCertificate(String),
+    #[error("BLS error: {0}")]
+    BlsError(String),
 }
 
 #[derive(Error, Debug, PartialEq)]


### PR DESCRIPTION
### Changes

- SDK
  - Store the node BLS proof of possession retrieved from the `info` API as `signer`. See [info.getNodeID](https://docs.avax.network/reference/avalanchego/info-api#infogetnodeid)
  - Allow to generate a new BLS private (or secret) key
- CLI
  - Add `avalanche node` subcommands: `pop-from-bls-key` and `generate-bls-key` that behave like `id-from-cert` and `generate-id`