### PR TITLE
feat(cli): add blockchain id-translate command

### DIFF
--- a/crates/ash_cli/src/avalanche/blockchain.rs
+++ b/crates/ash_cli/src/avalanche/blockchain.rs
@@ -72,6 +72,12 @@ enum BlockchainSubcommands {
         #[arg(long, short = 'w')]
         wait: bool,
     },
+    /// Get the hex encoded ID of a blockchain from its CB58 ID, or vice-versa
+    #[command(version = version_tx_cmd(false))]
+    TranslateId {
+        /// Blockchain CB58 or hex encoded ID
+        id: String,
+    },
 }
 
 fn create(
@@ -158,6 +164,29 @@ fn create(
     Ok(())
 }
 
+fn translate_id(id: &str, json: bool) -> Result<(), CliError> {
+    let id_parsed = parse_id(id)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "cb58": id_parsed.to_string(),
+                "hex": format!("0x{}", hex::encode(id_parsed))
+            })
+        );
+        return Ok(());
+    }
+
+    println!(
+        "CB58 ID: {}\nHex ID:  {}",
+        type_colorize(&id_parsed.to_string()),
+        type_colorize(&format!("0x{}", hex::encode(id_parsed)))
+    );
+
+    Ok(())
+}
+
 // Parse blockchain subcommand
 pub(crate) fn parse(
     subnet: BlockchainCommand,
@@ -189,5 +218,6 @@ pub(crate) fn parse(
             config,
             json,
         ),
+        BlockchainSubcommands::TranslateId { id } => translate_id(&id, json),
     }
 }

--- a/crates/ash_cli/src/utils/parsing.rs
+++ b/crates/ash_cli/src/utils/parsing.rs
@@ -10,8 +10,17 @@ use std::str::FromStr;
 
 // Parse an ID from a string
 pub(crate) fn parse_id(id: &str) -> Result<Id, CliError> {
-    let id = Id::from_str(id).map_err(|e| CliError::dataerr(format!("Error parsing ID: {e}")))?;
-    Ok(id)
+    // Try to parse the ID as CB58 first
+    let id_from_cb58 = Id::from_str(id);
+    if id_from_cb58.is_ok() {
+        return Ok(id_from_cb58.unwrap());
+    }
+
+    // Then try to parse it as hex
+    let id_bytes = hex::decode(id.trim_start_matches("0x"))
+        .map_err(|e| CliError::dataerr(format!("Error parsing ID: {e}")))?;
+
+    Ok(Id::from_slice(&id_bytes))
 }
 
 // Parse a node ID from a string


### PR DESCRIPTION
### Changes

- CLI
  - Allow to pass IDs in hexadecimal format (previously only supported CB58)
  - Add the `avalanche blockchain translate-id` command that takes the ID in either hex or CB58 string
