### PR TITLE
feat: avalanche subnet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "ash_api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "reqwest",
  "serde",

--- a/crates/ash_cli/src/console/resource.rs
+++ b/crates/ash_cli/src/console/resource.rs
@@ -143,8 +143,7 @@ pub(crate) fn create(
     let spinner = spinner_with_message("Creating resource...".to_string());
 
     // Deserialize the resource JSON
-    // TODO: Change to CreateResourceRequest when another resource type is added
-    let new_resource: console::api_models::NewAvalancheNodeResource =
+    let new_resource: console::api_models::CreateProjectResourceRequest =
         serde_yaml::from_str(&resource_str)
             .map_err(|e| CliError::dataerr(format!("Error parsing resource JSON: {e}")))?;
 
@@ -237,8 +236,7 @@ pub(crate) fn update(
     let spinner = spinner_with_message("Updating resource...".to_string());
 
     // Deserialize the resource JSON
-    // TODO: Change to UpdateResourceByIdRequest when another resource type is added
-    let update_resource_request: console::api_models::UpdateAvalancheNodeResource =
+    let update_resource_request: console::api_models::UpdateProjectResourceByIdOrNameRequest =
         serde_yaml::from_str(&resource_str)
             .map_err(|e| CliError::dataerr(format!("Error parsing resource JSON: {e}")))?;
 

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -472,11 +472,11 @@ pub(crate) fn template_avalanche_node_info(node: &AvalancheNode, indent: usize) 
         type_colorize(&node.http_port),
         type_colorize(&node.id),
         type_colorize(&match node.signer {
-            Some(ref signer) => format!("0x{}", hex::encode(&signer.public_key.clone())),
+            Some(ref signer) => format!("0x{}", hex::encode(signer.public_key.clone())),
             None => String::from("None"),
         }),
         type_colorize(&match node.signer {
-            Some(ref signer) => format!("0x{}", hex::encode(&signer.proof_of_possession.clone())),
+            Some(ref signer) => format!("0x{}", hex::encode(signer.proof_of_possession.clone())),
             None => String::from("None"),
         }),
         type_colorize(&node.network),

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -1105,6 +1105,34 @@ pub(crate) fn template_avalanche_node_props_table(
     props_table
 }
 
+pub(crate) fn template_avalanche_subnet_props_table(
+    avalanche_subnet: &console::api_models::GetAllProjectResources200ResponseInner,
+) -> Table {
+    let mut props_table = Table::new();
+    props_table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+
+    props_table.add_row(row![
+        "ID".bold(),
+        type_colorize(&avalanche_subnet.subnet_status.clone().unwrap().id.clone().unwrap_or_default()),
+    ]);
+    props_table.add_row(row![
+        "Validators",
+        type_colorize(
+            &avalanche_subnet
+                .subnet_status
+                .clone()
+                .unwrap()
+                .validators
+                .unwrap()
+                .len()
+        ),
+    ]);
+    
+    // TODO: Add the rest of the Subnet properties
+
+    props_table
+}
+
 pub(crate) fn template_resources_table(
     resources: Vec<console::api_models::GetAllProjectResources200ResponseInner>,
     project: console::api_models::Project,
@@ -1171,6 +1199,9 @@ pub(crate) fn template_resources_table(
             match *resource.resource_type.clone().unwrap_or_default() {
                 console::api_models::ResourceType::AvalancheNode => {
                     template_avalanche_node_props_table(&resource.clone())
+                }
+                console::api_models::ResourceType::AvalancheSubnet => {
+                    template_avalanche_subnet_props_table(&resource.clone())
                 }
             },
         ]);

--- a/crates/ash_sdk/Cargo.toml
+++ b/crates/ash_sdk/Cargo.toml
@@ -42,7 +42,7 @@ rustls-pemfile = "1.0.3"
 sha2 = "0.10.7"
 oauth2 = "4.4.2"
 url = "2.4.1"
-ash_api = { path = "../../../hai/ash-api-rs", version = "0.1.3" }
+ash_api = { path = "../../../hai/ash-api-rs", version = "0.1.4" }
 rcgen = "0.11.3"
 
 [dev-dependencies]


### PR DESCRIPTION
### Linked issues

- Fix #84 

### Dependencies

- https://github.com/AshAvalanche/ash-api-rs/pull/4

### Changes

- Just followed the `TODO` instructions to enable support for other resource 

### Additional comments

- The table for the `AvalancheSubnet` resource type could use some improvements
- I don't know what I missed but `ash console resource create '{ "name": "my-subnet-evm", "resourceType": "avalancheSubnet",[...]` fails with:

```
Error parsing resource JSON: resourceType: unknown variant `avalancheSubnet`, expected `avalancheNode` at line 3 column 19
```

`resource list` and `resource info` on `AvalancheSubnet` resources works fine tho