### PR TITLE
feat(wallet info): add both HEX and CB58 private key to the template.

### DIFF
--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -546,9 +546,13 @@ pub(crate) fn template_wallet_info(wallet_info: &AvalancheWalletInfo, indent: us
     info_str.push_str(&formatdoc!(
         "
         Wallet information:
-          X-Chain address: {}
-          P-Chain address: {}
-          EVM address:     {}",
+          HEX private key:  {}
+          CB58 private key: {}
+          X-Chain address:  {}
+          P-Chain address:  {}
+          EVM address:      {}",
+        type_colorize(&wallet_info.hex_private_key),
+        type_colorize(&wallet_info.cb58_private_key),
         type_colorize(&wallet_info.xchain_address),
         type_colorize(&wallet_info.pchain_address),
         type_colorize(&wallet_info.evm_address),

--- a/crates/ash_cli/src/utils/templating.rs
+++ b/crates/ash_cli/src/utils/templating.rs
@@ -546,7 +546,7 @@ pub(crate) fn template_wallet_info(wallet_info: &AvalancheWalletInfo, indent: us
     info_str.push_str(&formatdoc!(
         "
         Wallet information:
-          HEX private key:  {}
+          Hex private key:  {}
           CB58 private key: {}
           X-Chain address:  {}
           P-Chain address:  {}

--- a/crates/ash_sdk/src/avalanche/wallets.rs
+++ b/crates/ash_sdk/src/avalanche/wallets.rs
@@ -125,6 +125,10 @@ pub struct AvalancheWalletInfo {
     pub pchain_address: String,
     /// EVM address
     pub evm_address: String,
+    /// EVM formated Private key
+    pub hex_private_key : String,
+    /// AVAX formated Private key
+    pub cb58_private_key: String,
 }
 
 impl From<AvalancheWallet> for AvalancheWalletInfo {
@@ -133,6 +137,8 @@ impl From<AvalancheWallet> for AvalancheWalletInfo {
             xchain_address: wallet.xchain_wallet.x_address,
             pchain_address: wallet.pchain_wallet.p_address,
             evm_address: wallet.xchain_wallet.eth_address,
+            hex_private_key: wallet.private_key.to_hex(),
+            cb58_private_key: wallet.private_key.to_cb58(),
         }
     }
 }

--- a/crates/ash_sdk/src/avalanche/wallets.rs
+++ b/crates/ash_sdk/src/avalanche/wallets.rs
@@ -125,9 +125,9 @@ pub struct AvalancheWalletInfo {
     pub pchain_address: String,
     /// EVM address
     pub evm_address: String,
-    /// EVM formated Private key
+    /// Hex-encoded private key
     pub hex_private_key : String,
-    /// AVAX formated Private key
+    /// CB58-encoded private key
     pub cb58_private_key: String,
 }
 


### PR DESCRIPTION
### Changes

- Add HEX and CB58 private keys on the wallet info template.
- Update the struct and impl of AvalancheWalletInfo.