### PR TITLE
Delete pending validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,9 @@ dependencies = [
 
 [[package]]
 name = "ash_api"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128e8c7a21a6d998c954ff1ff987121ade10b92ef514b9bf2d1635d2ba51a2f0"
 dependencies = [
  "reqwest",
  "serde",
@@ -173,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "ash_cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ash_sdk",
  "async-std",
@@ -202,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "ash_sdk"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ash_api",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "ash_cli"
-version = "0.4.2"
+version = "0.4.3-rc.1"
 dependencies = [
  "ash_sdk",
  "async-std",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "ash_sdk"
-version = "0.4.2"
+version = "0.4.3-rc.1"
 dependencies = [
  "ash_api",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/ash_cli", "crates/ash_sdk"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3-rc.1"
 edition = "2021"
 authors = ["E36 Knots"]
 homepage = "https://ash.center"

--- a/crates/ash_cli/Cargo.toml
+++ b/crates/ash_cli/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-ash_sdk = { path = "../ash_sdk", version = "0.4.2" }
+ash_sdk = { path = "../ash_sdk", version = "0.4.3-rc.1" }
 clap = { version = "4.0.32", features = ["derive", "env", "cargo", "string"] }
 colored = "2.0.0"
 exitcode = "1.1.2"

--- a/crates/ash_cli/src/avalanche.rs
+++ b/crates/ash_cli/src/avalanche.rs
@@ -66,17 +66,6 @@ fn update_subnet_validators(
     Ok(())
 }
 
-// Update a Subnet's pending validators
-fn update_subnet_pending_validators(
-    network: &mut AvalancheNetwork,
-    subnet_id: &str,
-) -> Result<(), CliError> {
-    network
-        .update_subnet_pending_validators(parse_id(subnet_id)?)
-        .map_err(|e| CliError::dataerr(format!("Error updating pending validators: {e}")))?;
-    Ok(())
-}
-
 // Parse avalanche subcommand
 pub(crate) fn parse(
     avalanche: AvalancheCommand,

--- a/crates/ash_cli/src/avalanche/subnet.rs
+++ b/crates/ash_cli/src/avalanche/subnet.rs
@@ -94,7 +94,6 @@ fn info(
     let mut network = load_network(network_name, config)?;
     update_network_subnets(&mut network)?;
     update_subnet_validators(&mut network, id)?;
-    update_subnet_pending_validators(&mut network, id)?;
 
     let subnet = network
         .get_subnet(parse_id(id)?)

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -115,39 +115,22 @@ fn list(
     let subnet;
     let validators;
 
-    let first_line = match pending {
-        true => {
-            update_subnet_pending_validators(&mut network, subnet_id)?;
-            subnet = network
-                .get_subnet(parse_id(subnet_id)?)
-                .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
-            validators = subnet.pending_validators.clone();
-            format!(
-                "Found {} pending validators on Subnet '{}':",
-                type_colorize(&subnet.pending_validators.len()),
-                type_colorize(&subnet_id)
-            )
-        }
-        false => {
-            update_subnet_validators(&mut network, subnet_id)?;
-            subnet = network
-                .get_subnet(parse_id(subnet_id)?)
-                .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
-            validators = subnet.validators.clone();
-            format!(
-                "Found {} validators on Subnet '{}':",
-                type_colorize(&subnet.validators.len()),
-                type_colorize(&subnet_id)
-            )
-        }
-    };
+    update_subnet_validators(&mut network, subnet_id)?;
+    subnet = network
+        .get_subnet(parse_id(subnet_id)?)
+        .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
+    validators = subnet.validators.clone();
+    format!(
+        "Found {} validators on Subnet '{}':",
+        type_colorize(&subnet.validators.len()),
+        type_colorize(&subnet_id)
+    );
 
     if json {
         println!("{}", serde_json::to_string(&validators).unwrap());
         return Ok(());
     }
 
-    println!("{}", first_line);
     for validator in validators.iter() {
         println!(
             "{}",

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -89,11 +89,7 @@ enum ValidatorSubcommands {
     },
     /// List the Subnet's validators
     #[command(version = version_tx_cmd(false))]
-    List {
-        /// List pending validators
-        #[arg(long, short = 'p')]
-        pending: bool,
-    },
+    List,
     /// Show validator information
     #[command(version = version_tx_cmd(false))]
     Info {
@@ -106,7 +102,6 @@ enum ValidatorSubcommands {
 fn list(
     network_name: &str,
     subnet_id: &str,
-    pending: bool,
     config: Option<&str>,
     json: bool,
 ) -> Result<(), CliError> {
@@ -314,10 +309,9 @@ pub(crate) fn parse(
         ValidatorSubcommands::Info { id } => {
             info(&validator.network, &validator.subnet_id, &id, config, json)
         }
-        ValidatorSubcommands::List { pending } => list(
+        ValidatorSubcommands::List => list(
             &validator.network,
             &validator.subnet_id,
-            pending,
             config,
             json,
         ),

--- a/crates/ash_cli/src/avalanche/validator.rs
+++ b/crates/ash_cli/src/avalanche/validator.rs
@@ -107,14 +107,12 @@ fn list(
 ) -> Result<(), CliError> {
     let mut network = load_network(network_name, config)?;
     update_network_subnets(&mut network)?;
-    let subnet;
-    let validators;
 
     update_subnet_validators(&mut network, subnet_id)?;
-    subnet = network
+    let subnet = network
         .get_subnet(parse_id(subnet_id)?)
         .map_err(|e| CliError::dataerr(format!("Error listing validators: {e}")))?;
-    validators = subnet.validators.clone();
+    let validators = subnet.validators.clone();
     format!(
         "Found {} validators on Subnet '{}':",
         type_colorize(&subnet.validators.len()),
@@ -234,10 +232,7 @@ fn add(
                     start_time_parsed,
                     end_time_parsed,
                     delegation_fee,
-                    match signer {
-                        Some(_) => Some(signer_parsed),
-                        None => None,
-                    },
+                    signer.map(|_| signer_parsed),
                     wait,
                 )
                 .await
@@ -309,11 +304,6 @@ pub(crate) fn parse(
         ValidatorSubcommands::Info { id } => {
             info(&validator.network, &validator.subnet_id, &id, config, json)
         }
-        ValidatorSubcommands::List => list(
-            &validator.network,
-            &validator.subnet_id,
-            config,
-            json,
-        ),
+        ValidatorSubcommands::List => list(&validator.network, &validator.subnet_id, config, json),
     }
 }

--- a/crates/ash_cli/src/utils/parsing.rs
+++ b/crates/ash_cli/src/utils/parsing.rs
@@ -11,9 +11,8 @@ use std::str::FromStr;
 // Parse an ID from a string
 pub(crate) fn parse_id(id: &str) -> Result<Id, CliError> {
     // Try to parse the ID as CB58 first
-    let id_from_cb58 = Id::from_str(id);
-    if id_from_cb58.is_ok() {
-        return Ok(id_from_cb58.unwrap());
+    if let Ok(id) = Id::from_str(id) {
+        return Ok(id);
     }
 
     // Then try to parse it as hex

--- a/crates/ash_sdk/src/avalanche.rs
+++ b/crates/ash_sdk/src/avalanche.rs
@@ -295,34 +295,6 @@ impl AvalancheNetwork {
         Ok(())
     }
 
-    /// Update the pending validators of a Subnet by querying an API endpoint
-    pub fn update_subnet_pending_validators(&mut self, subnet_id: Id) -> Result<(), AshError> {
-        let rpc_url = &self.get_pchain()?.rpc_url;
-
-        let validators = platformvm::get_pending_validators(rpc_url, subnet_id)?;
-
-        // Replace the pending validators of the Subnet
-        let mut subnet = self.get_subnet(subnet_id)?.clone();
-
-        subnet.pending_validators = validators;
-
-        // Get the index of the Subnet
-        let subnet_index = self
-            .subnets
-            .iter()
-            .position(|subnet| subnet.id == subnet_id)
-            .ok_or(AvalancheNetworkError::NotFound {
-                network: self.name.clone(),
-                target_type: "Subnet".to_string(),
-                target_value: subnet_id.to_string(),
-            })?;
-
-        // Replace the Subnet
-        self.subnets[subnet_index] = subnet;
-
-        Ok(())
-    }
-
     /// Check if the operation is allowed on the network
     /// If not, return an error
     fn check_operation_allowed(

--- a/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
@@ -134,7 +134,7 @@ mod tests {
     const AVAX_FUJI_CCHAIN_ID: &str = "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp";
     const AVAX_FUJI_XCHAIN_ID: &str = "2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm";
     // ID of a node operated by Ava Labs
-    const AVAX_FUJI_NODE_ID: &str = "NodeID-4B4rc5vdD1758JSBYL1xyvE5NHGzz6xzH";
+    const AVAX_FUJI_NODE_ID: &str = "NodeID-4KXitMCoE9p2BHA6VzXtaTxLoEjNDo2Pt";
 
     // Load the test network from the ASH_TEST_CONFIG file
     fn load_test_network() -> AvalancheNetwork {

--- a/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
+++ b/crates/ash_sdk/src/avalanche/jsonrpc/platformvm.rs
@@ -6,7 +6,7 @@
 use crate::avalanche::{
     blockchains::AvalancheBlockchain,
     jsonrpc::{get_json_rpc_req_result, JsonRpcResponse},
-    subnets::{AvalancheSubnet, AvalancheSubnetDelegator, AvalancheSubnetValidator},
+    subnets::{AvalancheSubnet, AvalancheSubnetValidator},
 };
 use crate::{errors::*, impl_json_rpc_response};
 use avalanche_types::{
@@ -51,7 +51,6 @@ impl_json_rpc_response!(
 );
 impl_json_rpc_response!(GetBlockchainsResponse, GetBlockchainsResult);
 impl_json_rpc_response!(GetCurrentValidatorsResponse, GetCurrentValidatorsResult);
-impl_json_rpc_response!(GetPendingValidatorsResponse, GetPendingValidatorsResult);
 
 /// Get the Subnets of the network by querying the P-Chain API
 pub fn get_network_subnets(
@@ -122,47 +121,6 @@ pub fn get_current_validators(
         .collect();
 
     Ok(current_validators)
-}
-
-/// Get the pending validators of a Subnet by querying the P-Chain API
-pub fn get_pending_validators(
-    rpc_url: &str,
-    subnet_id: Id,
-) -> Result<Vec<AvalancheSubnetValidator>, RpcError> {
-    let pending_validators_result: GetPendingValidatorsResult =
-        get_json_rpc_req_result::<GetPendingValidatorsResponse, GetPendingValidatorsResult>(
-            rpc_url,
-            "platform.getPendingValidators",
-            Some(ureq::json!({ "subnetID": subnet_id.to_string() })),
-        )?;
-
-    let mut pending_validators: Vec<AvalancheSubnetValidator> = pending_validators_result
-        .validators
-        .iter()
-        .map(|validator| AvalancheSubnetValidator::from_api_primary_validator(validator, subnet_id))
-        .collect();
-    let pending_validators_iter = pending_validators.clone();
-
-    // For each pending validator, add related delegators
-    for pending_validator in pending_validators_iter.iter() {
-        let delegators: Vec<AvalancheSubnetDelegator> = pending_validators_result
-            .delegators
-            .iter()
-            .filter(|delegator| delegator.node_id == pending_validator.node_id)
-            .cloned()
-            .map(Into::into)
-            .collect();
-
-        if !delegators.is_empty() {
-            pending_validators
-                .iter_mut()
-                .find(|validator| validator.node_id == pending_validator.node_id)
-                .unwrap()
-                .delegators = Some(delegators);
-        }
-    }
-
-    Ok(pending_validators)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Changes

- delete every notion of pending validators 
- fit the need of the new AvalancheGo 1.11.3 version 

### Additional comments

This is the v0.4.3-rc.1 tag release. When merged, we'll need to update the version of the release to 0.4.3.
